### PR TITLE
Guard issue references from GitHub closing syntax

### DIFF
--- a/docs/agents/commits.md
+++ b/docs/agents/commits.md
@@ -11,6 +11,9 @@
 
 - Make each commit one self-contained reasoning step rather than splitting mechanically by file or module.
 - Use a concise imperative subject that explains what the change achieves. Add a body when the reason is not evident.
+- Treat commit subjects and bodies as GitHub issue-linking input. Do not place a GitHub closing keyword before an issue
+  reference unless merging that commit is intended to close the issue automatically; negated wording can still trigger
+  GitHub's pattern matching. Use neutral issue references as described in `docs/agents/pull-requests.md`.
 - Keep a test with the production change that makes it pass. Do not commit a deliberately failing TDD step.
 - Run proportionate validation before each commit and keep required documentation consistent with the branch tip.
 

--- a/docs/agents/pull-requests.md
+++ b/docs/agents/pull-requests.md
@@ -6,6 +6,11 @@ or documentation semantics.
 ## Scope and evidence
 
 - Link the confirmed issue or work item and state what remains deferred.
+- Treat GitHub closing keywords as mechanical syntax, not prose. In pull-request titles and bodies, never place `close`,
+  `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves`, or `resolved` before an issue reference unless the
+  pull request is intended to close that issue automatically. Negation, quotation, code formatting, and explanatory
+  context do not make the pattern safe. For non-closing relationships, use neutral wording such as `Related: #123`,
+  `Issue #123 remains open`, or `This pull request leaves the issue state unchanged`.
 - Keep the PR summary, compatibility impact, generated-output impact, and validation evidence current.
 - Inspect all required CI and SonarCloud findings for the current revision. A green job proves the tested state, not that
   an architectural decision has been made.


### PR DESCRIPTION
## Summary

- treat GitHub closing keywords as mechanical syntax in pull-request and commit text
- require neutral wording for relationships that must not change issue state

## Validation

- git diff --check