### PR TITLE
Publish stable Java module identities

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,10 @@
 
 ## Unreleased
 
-No user-visible product changes have been recorded for the next release yet.
+- Published Java-facing artifacts now declare stable automatic module names for JPMS consumers. The global-AST service
+  provider is packaged with its service descriptor, preserving classpath discovery while enabling module-path use. The
+  Gradle plugin remains build-tool-only and the annotation processor remains processor-path-oriented. See
+  [the module-path migration notes](docs/migration/0.x-to-1.0-module-path.md).
 
 ## Historical releases
 

--- a/README.md
+++ b/README.md
@@ -25,12 +25,31 @@ Anno-Docimal consists of the following modules:
 
 1. `anno-docimal-annotation` contains the `@AnnoDoc` annotation. Since we use retention `RUNTIME`, it must be present at runtime.
 2. `anno-docimal-ast` contains a groovy AST transformation that converts existing javadoc comments into `@AnnoDoc` annotations. It also contains helper code to simplify conversion and creation of JavaDoc annotations. This is necessary if the actual generator creates additional methods or inner classes. It only needs to be present at compile time, usually as a dependency of the generating library.
-3. `anno-docimal-global-ast` only consist of a global AST transformation descriptor pointing to `InlineJavadocsTransformation` and anno-docimal-ast as transitive dependency. It is meant to be included in the build process (compile-only).
+3. `anno-docimal-global-ast` contains the global AST transformation provider and its service descriptor, delegating to the reusable local transformation in `anno-docimal-ast`. It is meant to be included in the build process (compile-only).
 4. `anno-docimal-apt` contains an annotation processor that can be used to extract the javadoc from java source files. Since annotation processors cannot modify existing classes, it stores the javaodcs in a separate properties file, which is included in the jar file. These properties will also be consulted when trying to read or use the javadoc of a class or method object.
 5. `anno-docimal-generator` contains the main tool that reads the `@AnnoDoc` annotations and creates the stub files. It is meant to be included in the build process (and will eventually be packed as a gradle and/or maven plugin).
 6. `anno-docimal-gradle-plugin` consists of two gradle plugins that perform the following actions:
     - `com.blackbuild.annodocimal.base-plugin` creates a `createClassStubs` task that is configured to create doc stubs for all classes created from the main Groovy source set. It also remaps the existing `javadoc` task to use these stubs instead of the actual source files.
     - `com.blackbuild.annodocimal.plugin` is a convention plugin that applies the base plugin and configures all GroovyCompile tasks to include parameter names and javadoc comments in the AST. Both features are only available in Groovy 3.0 and later. The plugin activates parameter name inclusion in class files for all java compilations as well.
+
+## Java modules
+
+The Java-facing artifacts publish stable automatic module names. They can therefore be used on the module path without
+depending on a filename-derived name.
+
+| Artifact | Module name | Usage |
+|---|---|---|
+| `anno-docimal-annotations` | `com.blackbuild.annodocimal.annotations` | Runtime documentation carrier and capture marker |
+| `anno-docimal-apt` | `com.blackbuild.annodocimal.apt` | Annotation-processor path tooling; not an application-module dependency |
+| `anno-docimal-ast` | `com.blackbuild.annodocimal.ast` | Compile-time local Groovy AST transformation and helpers |
+| `anno-docimal-global-ast` | `com.blackbuild.annodocimal.global.ast` | Compile-time global Groovy AST provider |
+| `anno-docimal-generator` | `com.blackbuild.annodocimal.generator` | Source-projection tooling |
+| `anno-docimal-gradle-plugin` | — | Build-tool-only; intentionally outside JPMS |
+
+The AST artifacts remain compatible with one set of AnnoDocimal coordinates across Groovy 3, 4, and 5. This initial
+contract deliberately uses automatic modules rather than explicit descriptors, because the Groovy module name differs
+between the supported generations. See the [module-path migration notes](docs/migration/0.x-to-1.0-module-path.md) when
+upgrading an existing named consumer.
    
 # Usage
 

--- a/anno-docimal-annotations/build.gradle
+++ b/anno-docimal-annotations/build.gradle
@@ -4,6 +4,10 @@ plugins {
 
 description "Annotations for AnnoDocimal"
 
+tasks.withType(org.gradle.jvm.tasks.Jar).configureEach {
+    manifest.attributes('Automatic-Module-Name': 'com.blackbuild.annodocimal.annotations')
+}
+
 publishing {
     publications {
         mavenJava(MavenPublication) {

--- a/anno-docimal-annotations/build.gradle
+++ b/anno-docimal-annotations/build.gradle
@@ -1,10 +1,12 @@
+import org.gradle.jvm.tasks.Jar
+
 plugins {
     id "annodocimal-base.conventions"
 }
 
 description "Annotations for AnnoDocimal"
 
-tasks.withType(org.gradle.jvm.tasks.Jar).configureEach {
+tasks.withType(Jar).configureEach {
     manifest.attributes('Automatic-Module-Name': 'com.blackbuild.annodocimal.annotations')
 }
 

--- a/anno-docimal-apt/build.gradle
+++ b/anno-docimal-apt/build.gradle
@@ -1,10 +1,12 @@
+import org.gradle.jvm.tasks.Jar
+
 plugins {
     id "annodocimal-multigroovy.conventions"
 }
 
 description "Annotation Processor for AnnoDocimal"
 
-tasks.withType(org.gradle.jvm.tasks.Jar).configureEach {
+tasks.withType(Jar).configureEach {
     manifest.attributes('Automatic-Module-Name': 'com.blackbuild.annodocimal.apt')
 }
 

--- a/anno-docimal-apt/build.gradle
+++ b/anno-docimal-apt/build.gradle
@@ -4,6 +4,10 @@ plugins {
 
 description "Annotation Processor for AnnoDocimal"
 
+tasks.withType(org.gradle.jvm.tasks.Jar).configureEach {
+    manifest.attributes('Automatic-Module-Name': 'com.blackbuild.annodocimal.apt')
+}
+
 dependencies {
     api project(':anno-docimal-annotations')
     compileOnly 'com.google.auto.service:auto-service-annotations:1.1.0'

--- a/anno-docimal-ast/build.gradle
+++ b/anno-docimal-ast/build.gradle
@@ -5,6 +5,10 @@ plugins {
 
 description "compileOnly part of AnnoDocimal"
 
+tasks.withType(org.gradle.jvm.tasks.Jar).configureEach {
+    manifest.attributes('Automatic-Module-Name': 'com.blackbuild.annodocimal.ast')
+}
+
 dependencies {
     // all dependencies are compile time dependencies (for AST "runtime" is compile time of a client project")
     api project(':anno-docimal-annotations')

--- a/anno-docimal-ast/build.gradle
+++ b/anno-docimal-ast/build.gradle
@@ -1,11 +1,13 @@
+import org.gradle.jvm.tasks.Jar
+
 plugins {
     id "annodocimal-multigroovy.conventions"
     id 'java-test-fixtures'
 }
 
-description "compileOnly part of AnnoDocimal"
+description "Groovy AST documentation capture and helper APIs for AnnoDocimal"
 
-tasks.withType(org.gradle.jvm.tasks.Jar).configureEach {
+tasks.withType(Jar).configureEach {
     manifest.attributes('Automatic-Module-Name': 'com.blackbuild.annodocimal.ast')
 }
 

--- a/anno-docimal-generator/build.gradle
+++ b/anno-docimal-generator/build.gradle
@@ -5,6 +5,10 @@ plugins {
 
 description "compileOnly part of AnnoDocimal"
 
+tasks.withType(org.gradle.jvm.tasks.Jar).configureEach {
+    manifest.attributes('Automatic-Module-Name': 'com.blackbuild.annodocimal.generator')
+}
+
 dependencies {
     // all dependencies are compile time dependencies (for AST "runtime" is compile time of a client project")
     implementation "com.squareup:javapoet:1.13.0"

--- a/anno-docimal-generator/build.gradle
+++ b/anno-docimal-generator/build.gradle
@@ -1,11 +1,13 @@
+import org.gradle.jvm.tasks.Jar
+
 plugins {
     id "annodocimal-multigroovy.conventions"
     id 'com.gradleup.shadow' version '8.3.4'
 }
 
-description "compileOnly part of AnnoDocimal"
+description "Source-projection generator for AnnoDocimal"
 
-tasks.withType(org.gradle.jvm.tasks.Jar).configureEach {
+tasks.withType(Jar).configureEach {
     manifest.attributes('Automatic-Module-Name': 'com.blackbuild.annodocimal.generator')
 }
 

--- a/anno-docimal-global-ast/build.gradle
+++ b/anno-docimal-global-ast/build.gradle
@@ -2,7 +2,13 @@ plugins {
     id "annodocimal-multigroovy.conventions"
 }
 
+import org.gradle.api.tasks.testing.Test
+
 description "compileOnly part of AnnoDocimal"
+
+tasks.withType(org.gradle.jvm.tasks.Jar).configureEach {
+    manifest.attributes('Automatic-Module-Name': 'com.blackbuild.annodocimal.global.ast')
+}
 
 dependencies {
     // all dependencies are compile time dependencies (for AST "runtime" is compile time of a client project")
@@ -13,6 +19,24 @@ publishing {
     publications {
         mavenJava(MavenPublication) {
             from(components.java)
+        }
+    }
+}
+
+def moduleArtifacts = [
+        annotations: project(':anno-docimal-annotations').tasks.named('jar').flatMap { it.archiveFile },
+        apt        : project(':anno-docimal-apt').tasks.named('jar').flatMap { it.archiveFile },
+        ast        : project(':anno-docimal-ast').tasks.named('jar').flatMap { it.archiveFile },
+        globalAst  : tasks.named('jar').flatMap { it.archiveFile },
+        generator  : project(':anno-docimal-generator').tasks.named('shadowJar').flatMap { it.archiveFile }
+]
+
+tasks.withType(Test).configureEach {
+    dependsOn(moduleArtifacts.values())
+    inputs.files(moduleArtifacts.values())
+    doFirst {
+        moduleArtifacts.each { name, archive ->
+            systemProperty("annodocimal.module.$name", archive.get().asFile.absolutePath)
         }
     }
 }

--- a/anno-docimal-global-ast/build.gradle
+++ b/anno-docimal-global-ast/build.gradle
@@ -1,12 +1,13 @@
+import org.gradle.api.tasks.testing.Test
+import org.gradle.jvm.tasks.Jar
+
 plugins {
     id "annodocimal-multigroovy.conventions"
 }
 
-import org.gradle.api.tasks.testing.Test
+description "Global Groovy AST documentation capture for AnnoDocimal"
 
-description "compileOnly part of AnnoDocimal"
-
-tasks.withType(org.gradle.jvm.tasks.Jar).configureEach {
+tasks.withType(Jar).configureEach {
     manifest.attributes('Automatic-Module-Name': 'com.blackbuild.annodocimal.global.ast')
 }
 

--- a/anno-docimal-global-ast/src/main/java/com/blackbuild/annodocimal/global/ast/InlineJavadocsGlobalTransformation.java
+++ b/anno-docimal-global-ast/src/main/java/com/blackbuild/annodocimal/global/ast/InlineJavadocsGlobalTransformation.java
@@ -21,37 +21,28 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package com.blackbuild.annodocimal.ast;
+package com.blackbuild.annodocimal.global.ast;
 
-import org.codehaus.groovy.GroovyBugError;
-import org.codehaus.groovy.ast.*;
+import com.blackbuild.annodocimal.ast.InlineJavadocsTransformation;
+import org.codehaus.groovy.ast.ASTNode;
 import org.codehaus.groovy.control.CompilePhase;
 import org.codehaus.groovy.control.SourceUnit;
-import org.codehaus.groovy.transform.AbstractASTTransformation;
+import org.codehaus.groovy.transform.ASTTransformation;
 import org.codehaus.groovy.transform.GroovyASTTransformation;
 
-import java.util.Arrays;
-
 /**
- * AST transformation that inlines Javadoc comments as annotations. This transformation
- * can operate either as local ast transformation but adding it to a given annotation
- * with <code>{@literal @}GroovyASTTransformationClass("com.blackbuild.annodocimal.ast.InlineJavadocsTransformation")</code>
- * or using the <code>{@literal @}InlineJavadocs</code> annotation,
- * or as global transformation by including the {@code anno-docimal-global-ast} artifact as a compile-time dependency.
+ * Global AST transformation provider that delegates documentation capture to the reusable local transformation.
+ *
+ * <p>This provider and its service declaration are packaged together so global transformation discovery works on both
+ * the class path and module path.</p>
  */
 @GroovyASTTransformation(phase = CompilePhase.SEMANTIC_ANALYSIS)
-public class InlineJavadocsTransformation extends AbstractASTTransformation {
+public class InlineJavadocsGlobalTransformation implements ASTTransformation {
+
+    private final InlineJavadocsTransformation delegate = new InlineJavadocsTransformation();
 
     @Override
     public void visit(ASTNode[] nodes, SourceUnit source) {
-        this.sourceUnit = source;
-        InlineJavadocsVisitor visitor = new InlineJavadocsVisitor(source);
-        if (nodes != null && nodes.length == 2 && nodes[0] instanceof AnnotationNode && nodes[1] instanceof AnnotatedNode) {
-            visitor.visitClass((ClassNode) nodes[1]);
-        } else if (nodes == null || nodes.length == 1 && nodes[0] instanceof ModuleNode) {
-            source.getAST().getClasses().forEach(visitor::visitClass);
-        } else {
-            throw new GroovyBugError("Internal error: expecting [AnnotationNode, AnnotatedNode] or [ModuleNode] but got: " + Arrays.asList(nodes));
-        }
+        delegate.visit(nodes, source);
     }
 }

--- a/anno-docimal-global-ast/src/main/resources/META-INF/services/org.codehaus.groovy.transform.ASTTransformation
+++ b/anno-docimal-global-ast/src/main/resources/META-INF/services/org.codehaus.groovy.transform.ASTTransformation
@@ -1,1 +1,1 @@
-com.blackbuild.annodocimal.ast.InlineJavadocsTransformation
+com.blackbuild.annodocimal.global.ast.InlineJavadocsGlobalTransformation

--- a/anno-docimal-global-ast/src/test/groovy/com/blackbuild/annodocimal/ast/ModulePathVerificationTest.groovy
+++ b/anno-docimal-global-ast/src/test/groovy/com/blackbuild/annodocimal/ast/ModulePathVerificationTest.groovy
@@ -1,0 +1,144 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2024 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.blackbuild.annodocimal.ast
+
+import spock.lang.Specification
+
+import java.util.spi.ToolProvider
+
+class ModulePathVerificationTest extends Specification {
+
+    private static final Map<String, String> MODULE_NAMES = [
+            annotations: 'com.blackbuild.annodocimal.annotations',
+            apt        : 'com.blackbuild.annodocimal.apt',
+            ast        : 'com.blackbuild.annodocimal.ast',
+            globalAst  : 'com.blackbuild.annodocimal.global.ast',
+            generator  : 'com.blackbuild.annodocimal.generator'
+    ]
+
+    def 'published module-path artifacts expose their stable automatic module names'() {
+        expect:
+        MODULE_NAMES.every { artifact, moduleName ->
+            def result = runTool('jar', '--describe-module', '--file', moduleArtifact(artifact).absolutePath)
+            result.exitCode == 0 && result.output.readLines().any { it.startsWith("$moduleName@") && it.endsWith(' automatic') }
+        }
+    }
+
+    def 'global AST module owns the registered transformation provider'() {
+        when:
+        def result = runTool('jar', '--describe-module', '--file', moduleArtifact('globalAst').absolutePath)
+
+        then:
+        result.exitCode == 0
+        result.output.contains('provides org.codehaus.groovy.transform.ASTTransformation with com.blackbuild.annodocimal.global.ast.InlineJavadocsGlobalTransformation')
+    }
+
+    def 'named consumer compiles and runs with annotation, AST, and global service integration'() {
+        given:
+        def consumerDirectory = File.createTempDir('annodocimal-module-consumer', '')
+        def sourceDirectory = new File(consumerDirectory, 'com/example/consumer')
+        sourceDirectory.mkdirs()
+        new File(consumerDirectory, 'module-info.java').text = """
+            module com.example.annodocimal.consumer {
+                requires com.blackbuild.annodocimal.annotations;
+                requires com.blackbuild.annodocimal.ast;
+                requires com.blackbuild.annodocimal.global.ast;
+                requires ${groovyModuleName()};
+                uses org.codehaus.groovy.transform.ASTTransformation;
+            }
+        """.stripIndent()
+        new File(sourceDirectory, 'Consumer.java').text = '''
+            package com.example.consumer;
+
+            import com.blackbuild.annodocimal.annotations.InlineJavadocs;
+            import com.blackbuild.annodocimal.ast.InlineJavadocsTransformation;
+            import org.codehaus.groovy.transform.ASTTransformation;
+
+            import java.util.ServiceLoader;
+
+            @InlineJavadocs
+            public class Consumer {
+                public static void main(String[] args) {
+                    System.out.println(InlineJavadocsTransformation.class.getName());
+                    ServiceLoader.load(ASTTransformation.class).stream()
+                            .map(ServiceLoader.Provider::type)
+                            .map(Class::getName)
+                            .forEach(System.out::println);
+                }
+            }
+        '''.stripIndent()
+        def modulePath = [moduleArtifact('annotations'), moduleArtifact('ast'), moduleArtifact('globalAst'), groovyArtifact()].join(File.pathSeparator)
+        def outputDirectory = new File(consumerDirectory, 'classes')
+
+        when:
+        def compilation = runTool('javac', '--module-path', modulePath, '-d', outputDirectory.absolutePath,
+                new File(consumerDirectory, 'module-info.java').absolutePath, new File(sourceDirectory, 'Consumer.java').absolutePath)
+        def execution = runJava(modulePath, outputDirectory)
+
+        then:
+        compilation.exitCode == 0
+        execution.exitCode == 0
+        execution.output.contains('com.blackbuild.annodocimal.ast.InlineJavadocsTransformation')
+        execution.output.contains('com.blackbuild.annodocimal.global.ast.InlineJavadocsGlobalTransformation')
+
+        cleanup:
+        consumerDirectory.deleteDir()
+    }
+
+    private static File moduleArtifact(String artifact) {
+        new File(System.getProperty("annodocimal.module.$artifact"))
+    }
+
+    private static File groovyArtifact() {
+        new File(GroovySystem.protectionDomain.codeSource.location.toURI())
+    }
+
+    private static String groovyModuleName() {
+        def result = runTool('jar', '--describe-module', '--file', groovyArtifact().absolutePath)
+        assert result.exitCode == 0: result.output
+        result.output.readLines().find { it.endsWith(' automatic') }.tokenize('@')[0]
+    }
+
+    private static ToolResult runTool(String toolName, String... arguments) {
+        def output = new StringWriter()
+        int exitCode = ToolProvider.findFirst(toolName).orElseThrow().run(new PrintWriter(output), new PrintWriter(output), arguments)
+        new ToolResult(exitCode, output.toString())
+    }
+
+    private static ToolResult runJava(String modulePath, File outputDirectory) {
+        def process = new ProcessBuilder("${System.getProperty('java.home')}/bin/java", '--module-path', "$modulePath${File.pathSeparator}${outputDirectory.absolutePath}",
+                '-m', 'com.example.annodocimal.consumer/com.example.consumer.Consumer').redirectErrorStream(true).start()
+        new ToolResult(process.waitFor(), process.inputStream.text)
+    }
+
+    private static class ToolResult {
+        final int exitCode
+        final String output
+
+        ToolResult(int exitCode, String output) {
+            this.exitCode = exitCode
+            this.output = output
+        }
+    }
+}

--- a/docs/implementation/architecture-and-agent-baseline.md
+++ b/docs/implementation/architecture-and-agent-baseline.md
@@ -563,9 +563,10 @@ wiring currently belong to the consumer.
 - CI uses one Ubuntu/JDK 17 job and runs `build jacocoTestReport sonar`; the Gradle graph supplies compatibility lanes.
 - Six artifacts and two Gradle plugin markers are configured for publication through Maven Central/Plugin Portal tooling.
 - Most artifacts publish Gradle module metadata; the generator shadow publication does not.
-- Published Java-facing JARs have no explicit module descriptor or `Automatic-Module-Name`.
-- The global-AST JAR's service descriptor names a provider supplied by another artifact, preventing automatic module
-  derivation.
+- The five Java-facing module-path artifacts declare the stable automatic names confirmed for issue #36; the Gradle
+  plugin remains build-tool-only and outside JPMS, while the APT artifact remains processor-path-oriented.
+- The global-AST JAR packages its service descriptor with its provider adapter, which delegates to the reusable local
+  transformation in the AST artifact. Module-path and classpath discovery are exercised across Groovy 3, 4, and 5.
 
 ## Governance baseline established
 

--- a/docs/migration/0.x-to-1.0-module-path.md
+++ b/docs/migration/0.x-to-1.0-module-path.md
@@ -1,0 +1,26 @@
+# Module-path migration from 0.x to 1.0
+
+AnnoDocimal 1.0 assigns stable automatic Java module names to the published Java-facing artifacts. This replaces
+filename-derived names, which were not a supported compatibility contract in 0.x.
+
+Update a named consumer's `module-info.java` to use these names:
+
+| Artifact | Stable automatic module name |
+|---|---|
+| `anno-docimal-annotations` | `com.blackbuild.annodocimal.annotations` |
+| `anno-docimal-apt` | `com.blackbuild.annodocimal.apt` |
+| `anno-docimal-ast` | `com.blackbuild.annodocimal.ast` |
+| `anno-docimal-global-ast` | `com.blackbuild.annodocimal.global.ast` |
+| `anno-docimal-generator` | `com.blackbuild.annodocimal.generator` |
+
+Use `anno-docimal-apt` on the annotation-processor path, not as an application dependency. Keep
+`anno-docimal-gradle-plugin` in the build-tool classpath: it intentionally has no JPMS module contract.
+
+`anno-docimal-global-ast` still enables global documentation transformation through ordinary classpath service discovery.
+On the module path its service descriptor now names a provider in the same artifact, which delegates to the local
+transformation in `anno-docimal-ast`.
+
+The same AnnoDocimal artifact coordinates work with Groovy 3, 4, and 5. A named consumer that directly requires Groovy
+must use the module name provided by the selected Groovy generation (`org.codehaus.groovy` for Groovy 3 and
+`org.apache.groovy` for Groovy 4 and 5); AnnoDocimal does not impose an explicit descriptor that would choose between
+them.


### PR DESCRIPTION
## Summary

- publish stable automatic module names for the five Java-facing AnnoDocimal artifacts
- colocate the global AST service provider with its descriptor while preserving reusable local transformation behavior
- verify module-path use, service discovery, and the shared artifact set across Groovy 3, 4, and 5
- document the module contract and 0.x migration

## Validation

- `./gradlew check`

## Issue

Addresses #36.