### PR TITLE
Finalize the AnnoDocimal 1.0 supported API

### DIFF
--- a/docs/adr/0053-curate-the-1-0-transformation-author-api.md
+++ b/docs/adr/0053-curate-the-1-0-transformation-author-api.md
@@ -14,25 +14,26 @@ documentation carriers. Exact extraction never consults overridden declarations 
 separately named resolved-documentation capability.
 
 `Documentation` is a final immutable semantic value with value equality, immutable collections, `empty()`, `isEmpty()`,
-`builder()`, `toBuilder()`, `parse(String)`, and `render()`. Its stable vocabulary is summary, ordered paragraphs,
-parameter descriptions, optional return description, exception descriptions, repeatable tags, and template values.
+`builder()`, `toBuilder()`, `parse(String)`, and `render()`. Its stable vocabulary is an optional summary, ordered prose
+and code blocks, parameter descriptions, an optional return description, exception descriptions, repeatable tags,
+first-class links, and template values.
 Parsing and rendering operate on normalized documentation content and preserve meaning rather than source delimiters,
 whitespace, or original layout.
 
 `Documentation.Builder` is a transient mutable, non-thread-safe builder whose builds are independent immutable snapshots.
-Its confirmed non-template operations set the summary; add or replace paragraphs; add or replace parameter, return,
-exception, and tag content; merge missing content from a fallback with existing content winning; and build. Null values and
-blank parameter, exception, or tag names are rejected. Blank descriptions are allowed. Replacing an existing parameter
-or exception does not change its insertion position, repeated tags append, collection setters replace their category,
-and empty collections clear it.
+Its operations set or explicitly clear singular content; add or replace blocks, parameters, exceptions, and tags; add
+named template values; append a fallback with existing singular/named content winning; replace the whole document;
+filter parameters; and build. Null arguments are rejected throughout. Blank descriptions remain valid, while block text
+and names must be non-blank. Replacing an existing parameter or exception does not change its insertion position,
+repeated tags append, collection setters replace their category, and empty collections clear it.
 
-The template and richer authoring-language members of the builder remain provisional until issue #51 is decided with
-KlumAST issue #489. That gate includes code blocks, possible paragraph kinds, substitution and escaping, missing-value and
-failure behavior, merge rules, and the final template-member allowlist. It remains a 1.0 blocker and does not preserve the
-current 0.x template helpers as API.
+Issue #51 and KlumAST #489 completed the authoring-language decision recorded in ADR 0057. ADR 0058 reconciles the first
+implementation with the final 1.0 Java shape: optional scalar accessors, explicit clear operations, a typed template map,
+uniform value semantics, strict null handling, and removal of redundant aliases before the baseline is locked.
 
-The 1.0 allowlist contains only `AstDocumentation`, `Documentation`, and `Documentation.Builder`, plus the authoring
-members later accepted by issue #51. `ASTExtractor`, `ClassDocExtractor`, `InheritanceUtil`, the source extractors and
+The 1.0 allowlist contains exactly `AstDocumentation`, `Documentation`, `Documentation.Builder`, `Documentation.Block`,
+`Documentation.Tag`, `Documentation.Link`, and `Documentation.TemplateException`. `ASTExtractor`, `ClassDocExtractor`,
+`InheritanceUtil`, the source extractors and
 Groovy-version adapters, `DocText`, the current builders, `TemplateHandler`, `JavaDocUtil`, `AnnoDocUtil`, visitors,
 transformations, and metadata caches are implementation-only or replaced. No 0.x shim is retained merely for
 compatibility. This resolves issue #18's naming concern without merging source capture and AST extraction, which remain

--- a/docs/adr/0053-curate-the-1-0-transformation-author-api.md
+++ b/docs/adr/0053-curate-the-1-0-transformation-author-api.md
@@ -1,0 +1,39 @@
+# Curate the 1.0 transformation-author API
+
+The supported transformation-author facade is `com.blackbuild.annodocimal.ast.AstDocumentation`. It is a non-
+instantiable capability facade with these supported operations:
+
+- `extractExact(AnnotatedNode)` returns `Optional<Documentation>` for documentation attached directly to that declaration;
+- `attach(AnnotatedNode, Documentation)` canonically upserts the AnnoDocimal carrier;
+- `attachText(AnnotatedNode, String)` bridges normalized textual content into the same attachment behavior; and
+- `referenceTo(AnnotatedNode)` returns the canonical documentation reference for a declaration.
+
+`attach` replaces the existing AnnoDocimal carrier, applies target-parameter filtering and template values, refreshes
+AnnoDocimal metadata, and removes the canonical carrier when given empty documentation. It does not remove third-party
+documentation carriers. Exact extraction never consults overridden declarations or supertypes; issue #10 owns a future,
+separately named resolved-documentation capability.
+
+`Documentation` is a final immutable semantic value with value equality, immutable collections, `empty()`, `isEmpty()`,
+`builder()`, `toBuilder()`, `parse(String)`, and `render()`. Its stable vocabulary is summary, ordered paragraphs,
+parameter descriptions, optional return description, exception descriptions, repeatable tags, and template values.
+Parsing and rendering operate on normalized documentation content and preserve meaning rather than source delimiters,
+whitespace, or original layout.
+
+`Documentation.Builder` is a transient mutable, non-thread-safe builder whose builds are independent immutable snapshots.
+Its confirmed non-template operations set the summary; add or replace paragraphs; add or replace parameter, return,
+exception, and tag content; merge missing content from a fallback with existing content winning; and build. Null values and
+blank parameter, exception, or tag names are rejected. Blank descriptions are allowed. Replacing an existing parameter
+or exception does not change its insertion position, repeated tags append, collection setters replace their category,
+and empty collections clear it.
+
+The template and richer authoring-language members of the builder remain provisional until issue #51 is decided with
+KlumAST issue #489. That gate includes code blocks, possible paragraph kinds, substitution and escaping, missing-value and
+failure behavior, merge rules, and the final template-member allowlist. It remains a 1.0 blocker and does not preserve the
+current 0.x template helpers as API.
+
+The 1.0 allowlist contains only `AstDocumentation`, `Documentation`, and `Documentation.Builder`, plus the authoring
+members later accepted by issue #51. `ASTExtractor`, `ClassDocExtractor`, `InheritanceUtil`, the source extractors and
+Groovy-version adapters, `DocText`, the current builders, `TemplateHandler`, `JavaDocUtil`, `AnnoDocUtil`, visitors,
+transformations, and metadata caches are implementation-only or replaced. No 0.x shim is retained merely for
+compatibility. This resolves issue #18's naming concern without merging source capture and AST extraction, which remain
+different compiler-phase capabilities.

--- a/docs/adr/0054-define-the-1-0-source-projection-contract.md
+++ b/docs/adr/0054-define-the-1-0-source-projection-contract.md
@@ -1,0 +1,39 @@
+# Define the 1.0 source-projection contract
+
+`anno-docimal-generator` supports a final, thread-safe, reusable `SourceProjector` facade constructed with one non-null
+`ProjectionPolicy`. `projectToText(Path)` projects one caller-selected top-level class file to deterministic Java source.
+`projectToDirectory(Path, Path)` writes the identical text as UTF-8 with LF endings to the package/type-relative `.java`
+path beneath a caller-selected directory, creates required directories, replaces only that managed file atomically when
+the file system supports it, and returns the written path. Collection selection and stale-file cleanup belong to callers
+and tasks.
+
+Projection is documentation-oriented declaration reconstruction, not decompilation. The root declaration is always
+selected. `ProjectionPolicy.documentation()` includes public and protected declarations, recursively includes named
+member types, excludes synthetic declarations and Groovy runtime scaffolding, and includes visible language-level
+generated APIs. Local and anonymous classes are excluded. The policy is implementation-neutral: it does not expose ASM,
+Groovy-version adapters, visitors, JavaPoet, or bytecode flags.
+
+Signature closure is mandatory for every policy. It includes the minimum otherwise-excluded named member declarations
+and enclosing chain required to express selected signatures, including inherited generic substitutions. It never copies
+external dependency declarations. If one selected declaration cannot be represented validly, projection fails for that
+declaration instead of silently omitting it or erasing its types.
+
+`ProjectionPolicy` is a final immutable, thread-safe value with value equality, `documentation()`, `builder()`, and
+`toBuilder()`. `builder()` starts from the documentation preset; its nested builder is mutable and non-thread-safe and
+produces independent snapshots. The supported controls are included `DeclarationVisibility` values, nested-declaration
+inclusion, synthetic-declaration inclusion, and Groovy-runtime-artifact inclusion. Signature closure and valid output
+cannot be disabled. Annotation-presence filters are a future additive capability, not part of the 1.0 baseline.
+
+`DeclarationVisibility` is the only public projection enum and contains `PUBLIC`, `PROTECTED`, `PACKAGE_PRIVATE`, and
+`PRIVATE`. `SourceProjectionException` is a supported runtime exception for a readable class whose selected declaration
+cannot be projected. It identifies the input path and, when available, a stable declaration identifier while preserving
+the cause. Ordinary file-system failures remain `IOException`.
+
+Top-level selection is semantic. A direct projection root must be a top-level declaration according to class metadata;
+named nested declarations are discovered from that root. Issue #39 may document a filename-based limitation only if
+metadata classification proves disproportionately complex, and any such limitation remains a visible open flank rather
+than redefining top-level selection.
+
+The 1.0 generator allowlist is `SourceProjector`, `ProjectionPolicy`, `ProjectionPolicy.Builder`,
+`DeclarationVisibility`, and `SourceProjectionException`. `AnnoDocGenerator` is removed without a shim. Current visitors,
+converters, filters, annotation readers, ASM/JavaPoet types, and every relocated shaded type are implementation-only.

--- a/docs/adr/0055-stabilize-the-1-0-gradle-projection-contract.md
+++ b/docs/adr/0055-stabilize-the-1-0-gradle-projection-contract.md
@@ -1,0 +1,35 @@
+# Stabilize the 1.0 Gradle projection contract
+
+The supported reusable task type is `com.blackbuild.annodocimal.plugin.SourceProjectionTask`. It replaces
+`CreateClassStubs` without a shim. Its supported member allowlist is limited to the declarative getters for:
+
+- `@Classpath ConfigurableFileCollection classesDirectories`;
+- `@Input SetProperty<String> includes` and `excludes`;
+- `@Nested Property<ProjectionPolicy> projectionPolicy`; and
+- `@OutputDirectory DirectoryProperty outputDirectory`.
+
+There are no supported fluent configuration helpers, public task-action method, or subclassing SPI. The default selects
+all top-level class files and uses `ProjectionPolicy.documentation()`. Include and exclude values are Gradle/Ant patterns
+over slash-normalized paths relative to each classes directory, including the `.class` suffix; exclusions win. Matching
+creates candidates and class metadata then determines top-level status. Duplicate binary names from different input
+directories fail deterministically with both origins.
+
+The task exclusively owns its output directory. It projects the complete selection into staging and replaces the managed
+tree only after all projections succeed. A successful execution therefore removes stale files; a failed execution leaves
+the previous successful output intact. Input and output directories must not overlap. The task remains cacheable,
+documentation-sensitive, configuration-cache safe, and independently registrable; IDE model wiring remains consumer
+policy.
+
+The supported neutral plugin ID remains `com.blackbuild.annodocimal.base-plugin`. It applies neither Java nor Groovy. When
+Gradle's Java model appears it lazily registers the conventional `createClassStubs` instance over all main class
+directories and connects its output to `javadoc`. Without that model it registers and wires nothing, while consumers can
+still register `SourceProjectionTask` manually.
+
+The supported opinionated plugin ID is `com.blackbuild.annodocimal.groovy-plugin`. It replaces the ambiguous
+`com.blackbuild.annodocimal.plugin` ID without a shim, applies Gradle's Groovy plugin and the AnnoDocimal base plugin, and
+configures relevant Groovy and Java compilation tasks to retain documentation and parameter metadata. Both layers are
+lazy and configuration-cache safe. The plugin implementation classes are packaging details, not supported Java APIs.
+
+KlumAST's Groovy/Spock version convention may later move into an independent project that this plugin can mention or
+compose with. AnnoDocimal 1.0 neither depends on that future project nor absorbs its version-management role. A future
+Java-oriented convention plugin is likewise additive and outside 1.0.

--- a/docs/adr/0056-coordinate-the-authoring-language-with-klumast.md
+++ b/docs/adr/0056-coordinate-the-authoring-language-with-klumast.md
@@ -1,8 +1,8 @@
 # Coordinate the 1.0 authoring language with KlumAST
 
-The documentation authoring and template language must be stabilized before AnnoDocimal 1.0, but it is not decided by
-issue #37. AnnoDocimal issue #51 owns the reusable language and supported API; KlumAST issue #489 owns concrete consumer
-requirements and migration. This gate blocks the template-related portion of issue #38 but does not block issue #39.
+The documentation authoring and template language had to be stabilized before AnnoDocimal 1.0. AnnoDocimal issue #51
+owned the reusable language and supported API; KlumAST issue #489 owned concrete consumer requirements and migration.
+Both issues are complete, and ADR 0057 records the resulting language. They no longer block issue #38 or #39.
 
 KlumAST is the only proven current consumer and the primary driver for template substitution, code blocks, and possible
 paragraph kinds. klum-wrap predates AnnoDocimal and currently has no integration, but its AST-transformation focus makes
@@ -13,7 +13,6 @@ KlumCast's diagnostic message templates are a separate domain and impose no requ
 Their basic named-template mechanism should nevertheless be consulted for useful alignment. If real common logic emerges,
 a future separate library may own it; shared extraction is an option, not an objective or 1.0 dependency.
 
-Until the coordinated decision is complete, no existing 0.x authoring type is provisional API. `DocBuilder`,
-`JavadocDocBuilder`, `DocText`, and `TemplateHandler` remain implementation-only or replaced. Only the not-yet-final
-authoring members of `Documentation.Builder` are a provisional slot, with an explicit 1.0 disposition of resolve through
-issue #51 before the compatibility baseline is locked.
+The coordination did not promote any existing 0.x authoring type. `DocBuilder`, `JavadocDocBuilder`, `DocText`, and
+`TemplateHandler` remain implementation-only or replaced. The authoring slot is now final; ADR 0058 records the small
+pre-baseline API-shape corrections that issue #38 must make to the first implementation.

--- a/docs/adr/0056-coordinate-the-authoring-language-with-klumast.md
+++ b/docs/adr/0056-coordinate-the-authoring-language-with-klumast.md
@@ -1,0 +1,19 @@
+# Coordinate the 1.0 authoring language with KlumAST
+
+The documentation authoring and template language must be stabilized before AnnoDocimal 1.0, but it is not decided by
+issue #37. AnnoDocimal issue #51 owns the reusable language and supported API; KlumAST issue #489 owns concrete consumer
+requirements and migration. This gate blocks the template-related portion of issue #38 but does not block issue #39.
+
+KlumAST is the only proven current consumer and the primary driver for template substitution, code blocks, and possible
+paragraph kinds. klum-wrap predates AnnoDocimal and currently has no integration, but its AST-transformation focus makes
+it a likely future adopter; it is consulted as an adaptable consumer rather than a co-owner or source of hard
+requirements.
+
+KlumCast's diagnostic message templates are a separate domain and impose no requirement on documentation authoring.
+Their basic named-template mechanism should nevertheless be consulted for useful alignment. If real common logic emerges,
+a future separate library may own it; shared extraction is an option, not an objective or 1.0 dependency.
+
+Until the coordinated decision is complete, no existing 0.x authoring type is provisional API. `DocBuilder`,
+`JavadocDocBuilder`, `DocText`, and `TemplateHandler` remain implementation-only or replaced. Only the not-yet-final
+authoring members of `Documentation.Builder` are a provisional slot, with an explicit 1.0 disposition of resolve through
+issue #51 before the compatibility baseline is locked.

--- a/docs/adr/0058-reconcile-the-authoring-model-with-the-1-0-api.md
+++ b/docs/adr/0058-reconcile-the-authoring-model-with-the-1-0-api.md
@@ -1,0 +1,28 @@
+# Reconcile the authoring model with the 1.0 Java API
+
+Issue #51 and KlumAST #489 established the authoring language in ADR 0057 and delivered its first implementation. Before
+the 1.0 baseline is locked, issue #38 must make the following clean-cut Java API corrections. They refine the supported
+shape without changing the accepted documentation language.
+
+- `Documentation.getSummary()`, `Documentation.getReturnDescription()`, and `Documentation.Link.getLabel()` return
+  `Optional<String>`. The primary transformation consumers are Java implementations even when they transform Groovy;
+  Groovy 3, 4, and 5 also give `Optional` useful truth semantics.
+- Every public facade and builder argument rejects `null`. Blank descriptions remain valid. Empty replacement
+  collections clear their category. `clearSummary()` and `clearReturn()` are the explicit singular clearing operations.
+- `Documentation.parse(null)` rejects `null`, while blank text parses to `Documentation.empty()`.
+  `AstDocumentation.attach` rejects a null node or document; callers remove documentation with
+  `Documentation.empty()`. `attachText` rejects null input and treats blank input as empty/removal.
+- `Documentation`, `Documentation.Block`, `Documentation.Tag`, and `Documentation.Link` all have value-based
+  `equals`, `hashCode`, and diagnostic structural `toString`. `toString` must not render templates, and its exact text is
+  not a compatibility contract.
+- `Documentation.Builder.templateValues` accepts `Map<String, String>`. Raw Java and dynamic-language calls containing
+  null or non-string values still fail with the target and key context required by ADR 0057.
+- `paragraph` and `returns` are the single supported append/set names. The redundant `appendParagraph` and
+  `replaceReturn` aliases are removed before 1.0. Their semantics and the replacement operations remain explicit in
+  documentation rather than duplicated in method names.
+
+The final AST allowlist is therefore `AstDocumentation`, `Documentation`, `Documentation.Builder`,
+`Documentation.Block`, `Documentation.Tag`, `Documentation.Link`, and `Documentation.TemplateException`. No current
+0.x helper is retained as a shim. The scoped baseline introduced with issue #51 is evidence, not yet the final 1.0
+baseline: issue #38 must update it after these corrections, and the release compatibility work must apply the complete
+per-artifact rules in the supported-API record.

--- a/docs/api/1.0-supported-api.md
+++ b/docs/api/1.0-supported-api.md
@@ -2,11 +2,13 @@
 
 This record is the human-authoritative classification produced by issue #37. Java `public` visibility, inclusion in a
 published JAR, a service-provider name, or relocation into the generator artifact does not by itself make a type
-supported. Issues #38, #39, #35, and #51 must implement these allowlists and generate the initial mechanical signature
-snapshots from them.
+supported. Issues #38, #39, and #35 must finish these allowlists; release compatibility work generates the complete
+mechanical snapshots from them.
 
-The inventory below was taken from all six artifacts built from commit `981a511`. It contains every public top-level and
-nested type in those JARs, including the 79 public relocated types in the generator shadow JAR.
+The inventory began with all six artifacts at commit `981a511` and was refreshed through `505a4ae`, after the issue #51
+authoring implementation merged. It contains all 120 public top-level and nested types in those JARs: the original 113,
+the seven authoring types added by #51, and the 79 public relocated types within the generator total. The artifact counts
+are annotations 2, APT 2, AST 24, global AST 1, generator shadow JAR 88, and Gradle plugin 3.
 
 Classification terms are:
 
@@ -15,14 +17,19 @@ Classification terms are:
   consumer API; and
 - **provisional**: must receive its stated disposition before the 1.0 baseline is locked.
 
+No public type remains provisional after the issue #37 and #51 decisions. The merged authoring implementation still has
+the pre-baseline member corrections in ADR 0058; those do not make its seven selected types provisional.
+
 ## 1.0 allowlists by artifact
 
 ### `anno-docimal-annotations`
 
 Supported Java types and members:
 
-- `com.blackbuild.annodocimal.annotations.AnnoDoc`, including `value()`;
-- `com.blackbuild.annodocimal.annotations.InlineJavadocs` as a marker annotation.
+- `com.blackbuild.annodocimal.annotations.AnnoDoc`, including `value()`, runtime retention, and type/method/field/
+  constructor targets;
+- `com.blackbuild.annodocimal.annotations.InlineJavadocs` as a source-retained package/type marker whose presence
+  triggers local capture.
 
 The externally observable `__annodoc.properties` resource suffix and the class, method, and field key semantics
 are supported data-protocol behavior. `InlineJavadocs.JAVADOC_PROPERTIES_SUFFIX` is not supported Java API and is removed
@@ -39,11 +46,33 @@ Supported Java types:
 
 - `com.blackbuild.annodocimal.ast.AstDocumentation`;
 - `com.blackbuild.annodocimal.ast.Documentation`;
-- `com.blackbuild.annodocimal.ast.Documentation.Builder`.
+- `com.blackbuild.annodocimal.ast.Documentation.Builder`;
+- `com.blackbuild.annodocimal.ast.Documentation.Block`;
+- `com.blackbuild.annodocimal.ast.Documentation.Tag`;
+- `com.blackbuild.annodocimal.ast.Documentation.Link`; and
+- `com.blackbuild.annodocimal.ast.Documentation.TemplateException`.
 
-ADR 0053 defines the confirmed members. The template and richer authoring-language members of `Documentation.Builder`
-are provisional with the explicit disposition **resolve through AnnoDocimal #51 and KlumAST #489 before 1.0**. No current
-0.x type is provisional API.
+The supported members after ADR 0058's pre-baseline corrections are:
+
+- `AstDocumentation`: `extractExact(AnnotatedNode)`, `attach(AnnotatedNode, Documentation)`,
+  `attachText(AnnotatedNode, String)`, and `referenceTo(AnnotatedNode)`;
+- `Documentation`: `empty()`, `builder()`, `parse(String)`, optional `getSummary()` and
+  `getReturnDescription()`, immutable `getBlocks()`, `getParameters()`, `getExceptions()`, `getTags()`, and
+  `getTemplateValues()`, `isEmpty()`, `toBuilder()`, both `render` forms, and value-based `equals`/`hashCode` plus
+  diagnostic `toString`;
+- `Documentation.Builder`: `summary`, `clearSummary`, `paragraph`, `codeBlock`, `replaceBlocks`, `param`,
+  `replaceParameters`, `returns`, `clearReturn`, `throwsException`, `replaceExceptions`, `tag`, `deprecated`, `see`,
+  `seeText`, `replaceTags`, `template`, `templateValues(Map<String, String>)`, `append`, `replace`,
+  `filterParameters`, and `build`;
+- `Documentation.Block`: `getText`, `isCode`, and value methods;
+- `Documentation.Tag`: `getName`, `getValue`, and value methods;
+- `Documentation.Link`: both `text` factories, `getTarget`, optional `getLabel`, `inline`, and value methods; and
+- `Documentation.TemplateException`: the catchable runtime failure type for malformed or incomplete templates, without
+  a public construction or subclassing contract.
+
+`appendParagraph` and `replaceReturn` are not in the 1.0 allowlist. Exact extraction remains distinct from issue #10's
+future resolved/inherited extraction. All public arguments reject null; blank text parsing and attachment map to empty
+documentation, and explicit empty/clear operations own removal semantics.
 
 Local `@InlineJavadocs` capture and its transformation registration are supported behavior. Transformation, visitor,
 parser, metadata, cache, and Groovy-version-adapter class names are packaging or implementation details.
@@ -100,6 +129,13 @@ methods are not supported Java APIs.
 
 | Current public type | Classification | 1.0 disposition |
 |---|---|---|
+| `com.blackbuild.annodocimal.ast.AstDocumentation` | supported | Retain the capability facade with only the four operations listed above. |
+| `com.blackbuild.annodocimal.ast.Documentation` | supported | Retain as the immutable semantic value after ADR 0058's member corrections. |
+| `com.blackbuild.annodocimal.ast.Documentation.Builder` | supported | Retain as a transient builder with the explicit member allowlist above. |
+| `com.blackbuild.annodocimal.ast.Documentation.Block` | supported | Retain as immutable prose/code vocabulary with uniform value semantics. |
+| `com.blackbuild.annodocimal.ast.Documentation.Tag` | supported | Retain as immutable ordered generic-tag vocabulary with uniform value semantics. |
+| `com.blackbuild.annodocimal.ast.Documentation.Link` | supported | Retain as immutable author-owned/canonical-reference vocabulary with an optional label. |
+| `com.blackbuild.annodocimal.ast.Documentation.TemplateException` | supported | Retain as the catchable template-render failure type; expose no construction SPI. |
 | `com.blackbuild.annodocimal.ast.extractor.ASTExtractor` | implementation-only | Replace with `AstDocumentation.extractExact`; do not retain its names, metadata constants, string fallback, or cache surface. |
 | `com.blackbuild.annodocimal.ast.extractor.ClassDocExtractor` | implementation-only | Hide behind exact extraction. |
 | `com.blackbuild.annodocimal.ast.extractor.InheritanceUtil` | implementation-only | Remove from 1.0 API; issue #10 owns later resolved extraction. |
@@ -112,7 +148,7 @@ methods are not supported Java APIs.
 | `com.blackbuild.annodocimal.ast.formatting.DocBuilder` | implementation-only | Replace with `Documentation.Builder`; no shim. |
 | `com.blackbuild.annodocimal.ast.formatting.AbstractDocBuilder` | implementation-only | Remove implementation inheritance. |
 | `com.blackbuild.annodocimal.ast.formatting.JavadocDocBuilder` | implementation-only | Replace with `Documentation.Builder`; no shim. |
-| `com.blackbuild.annodocimal.ast.formatting.TemplateHandler` | implementation-only | Remove from API; issue #51 selects the supported authoring language. |
+| `com.blackbuild.annodocimal.ast.formatting.TemplateHandler` | implementation-only | Remove from API; ADR 0057 defines the replacement authoring language. |
 | `com.blackbuild.annodocimal.ast.formatting.JavaDocUtil` | implementation-only | Replace declaration-link capability with `AstDocumentation.referenceTo`. |
 | `com.blackbuild.annodocimal.ast.formatting.AnnoDocUtil` | implementation-only | Replace attachment capability with `AstDocumentation.attach` and `attachText`. |
 | `com.blackbuild.annodocimal.ast.InlineJavadocsVisitor` | implementation-only | Hide capture visitor and metadata/cache technology. |
@@ -234,13 +270,20 @@ shadow.javapoet.WildcardTypeName
 ## Mechanical compatibility baseline
 
 The human classification above remains authoritative. Implementation must produce one machine-readable allowlist and one
-generated signature snapshot per Java-facing artifact, checked into version control. The build derives each snapshot from
-the built artifact filtered by that artifact's allowlist; a snapshot is never produced by accepting every public class.
+generated signature snapshot for each of the six published artifacts, checked into version control. An empty Java
+allowlist remains an explicit checked record for APT or global-AST artifacts whose supported contract is behavioral. The
+build derives each snapshot from the built artifact filtered by that artifact's allowlist; a snapshot is never produced
+by accepting every public class.
 
 The snapshots include supported top-level and nested types, constructors, methods, fields, enum constants, annotation
 members and defaults, generic signatures, superclass and interface relationships, visibility, and compatibility-relevant
 annotations. They exclude implementation-only types, provider names, shaded packages, task actions, and plugin
 implementation classes even when those remain public in bytecode.
+
+The issue #51 `1.0-authoring-api-baseline.txt` is the first scoped check, not the complete mechanism: it currently records
+selected type names and erased declared-method descriptors. Issue #38 must refresh it after ADR 0058, and the release
+baseline work must additionally capture constructors, fields, generic signatures, type relationships, annotation
+contracts/defaults, nested-type membership, and the other rules above rather than treating that file as sufficient.
 
 The compatibility check compares both source and binary contracts against the most recent released baseline and fails on
 incompatible removal, visibility reduction, descriptor or generic-signature change, superclass/interface change, or
@@ -253,6 +296,7 @@ resources, exact attachment/extraction behavior, projection semantics and determ
 output, plugin-ID behavior, and JPMS module names are not reduced to JVM signatures. The module names delivered by issue
 #36 remain stable and the baseline must not reopen KlumAST #455's separate multi-Groovy build decision.
 
-Issue #51 must resolve the provisional builder slot before the 1.0 snapshots are locked. Issues #38, #39, and #35 add the
-new supported types and members; the compatibility-baseline work then generates and verifies the initial snapshots from
-this record rather than from the 0.x public surface.
+Issue #51 resolved the former builder slot and introduced a scoped authoring baseline. Issue #38 applies ADR 0058's
+pre-1.0 corrections and refreshes that baseline. Issues #39 and #35 add the projection and Gradle types. Release
+compatibility work then generates and verifies complete per-artifact snapshots from this record rather than from the
+0.x public surface or from all public bytecode.

--- a/docs/api/1.0-supported-api.md
+++ b/docs/api/1.0-supported-api.md
@@ -1,33 +1,258 @@
-# 1.0 supported transformation-author API
+# AnnoDocimal 1.0 supported API
 
-This allowlist is the compatibility boundary for the authoring portion of `anno-docimal-ast`. Public visibility of other
-classes in the artifact does not make them supported. The mechanical baseline records only this list and its members.
+This record is the human-authoritative classification produced by issue #37. Java `public` visibility, inclusion in a
+published JAR, a service-provider name, or relocation into the generator artifact does not by itself make a type
+supported. Issues #38, #39, #35, and #51 must implement these allowlists and generate the initial mechanical signature
+snapshots from them.
 
-## Types and members
+The inventory below was taken from all six artifacts built from commit `981a511`. It contains every public top-level and
+nested type in those JARs, including the 79 public relocated types in the generator shadow JAR.
 
-- `AstDocumentation`: `extractExact`, `attach`, `attachText`, and `referenceTo`.
-- `Documentation`: `empty`, `builder`, `parse`, `isEmpty`, `toBuilder`, `render`, `render(Collection)`, and its value
-  accessors.
-- `Documentation.Builder`: summary, prose/code block, named parameter/exception, return, generic-tag, deprecated,
-  link, template, append, replace, parameter-filter, and `build` operations declared by the type.
-- `Documentation.Block`, `Documentation.Tag`, and `Documentation.Link` as immutable value vocabulary. A link renders
-  with `inline`; links produced from AST are created by `AstDocumentation.referenceTo`.
-- `Documentation.TemplateException` for template failures.
+Classification terms are:
 
-`ASTExtractor`, `ClassDocExtractor`, `InheritanceUtil`, source extractors, Groovy-version adapters, formatters,
-`DocBuilder`, `JavadocDocBuilder`, `DocText`, `TemplateHandler`, `JavaDocUtil`, `AnnoDocUtil`, visitors,
-transformations, and metadata keys are implementation machinery. They must not enter the 1.0 source or binary
-compatibility baseline.
+- **supported**: part of the 1.0 source/binary contract;
+- **implementation-only**: may remain public in bytecode when a framework or shading mechanism requires it, but is not a
+  consumer API; and
+- **provisional**: must receive its stated disposition before the 1.0 baseline is locked.
 
-## Mechanical baseline rules
+## 1.0 allowlists by artifact
 
-The checked-in `1.0-authoring-api-baseline.txt` test resource must include the selected top-level and nested types,
-constructors, methods, descriptors, generic
-signatures, visibility, superclass/interface relationships, enum constants, annotation members/defaults, and
-compatibility-relevant annotations. It must be derived from this allowlist—not from all public classes in a JAR.
+### `anno-docimal-annotations`
 
-It must fail on incompatible removal, visibility reduction, descriptor or generic-signature change,
-superclass/interface change, or compatibility-relevant annotation change. Compatible additions require an intentional
-allowlist update. Behavioral contracts such as exact extraction, normalized rendering, template failure context, AST
-link validation, carrier attachment, and final-signature parameter ordering have focused behavioral tests in addition to
-the signature baseline. The baseline test is part of the ordinary Gradle test/check lifecycle.
+Supported Java types and members:
+
+- `com.blackbuild.annodocimal.annotations.AnnoDoc`, including `value()`;
+- `com.blackbuild.annodocimal.annotations.InlineJavadocs` as a marker annotation.
+
+The externally observable `__annodoc.properties` resource suffix and the class, method, and field key semantics
+are supported data-protocol behavior. `InlineJavadocs.JAVADOC_PROPERTIES_SUFFIX` is not supported Java API and is removed
+or hidden in 1.0; no new public properties utility is introduced merely to expose that constant.
+
+### `anno-docimal-apt`
+
+The Java API allowlist is empty. Service-discovered annotation processing and its documentation-properties output are
+supported behavior. The processor provider name is a packaging obligation, not a construction or subclassing API.
+
+### `anno-docimal-ast`
+
+Supported Java types:
+
+- `com.blackbuild.annodocimal.ast.AstDocumentation`;
+- `com.blackbuild.annodocimal.ast.Documentation`;
+- `com.blackbuild.annodocimal.ast.Documentation.Builder`.
+
+ADR 0053 defines the confirmed members. The template and richer authoring-language members of `Documentation.Builder`
+are provisional with the explicit disposition **resolve through AnnoDocimal #51 and KlumAST #489 before 1.0**. No current
+0.x type is provisional API.
+
+Local `@InlineJavadocs` capture and its transformation registration are supported behavior. Transformation, visitor,
+parser, metadata, cache, and Groovy-version-adapter class names are packaging or implementation details.
+
+### `anno-docimal-global-ast`
+
+The Java API allowlist is empty. Adding the artifact to a Groovy compilation and discovering its global transformation
+provider are supported behavior. The provider class name remains a packaging obligation rather than a consumer API.
+
+### `anno-docimal-generator`
+
+Supported Java types:
+
+- `com.blackbuild.annodocimal.generator.SourceProjector`;
+- `com.blackbuild.annodocimal.generator.ProjectionPolicy`;
+- `com.blackbuild.annodocimal.generator.ProjectionPolicy.Builder`;
+- `com.blackbuild.annodocimal.generator.DeclarationVisibility`;
+- `com.blackbuild.annodocimal.generator.SourceProjectionException`.
+
+ADR 0054 defines their construction, lifecycle, policy, output, and failure contracts. No ASM, JavaPoet, visitor,
+converter, parser, filter, annotation-reader, or shaded type is supported.
+
+### `anno-docimal-gradle-plugin`
+
+The supported Java type allowlist contains only:
+
+- `com.blackbuild.annodocimal.plugin.SourceProjectionTask`, limited to the five property getters in ADR 0055.
+
+Supported plugin IDs and behavior:
+
+- `com.blackbuild.annodocimal.base-plugin`;
+- `com.blackbuild.annodocimal.groovy-plugin`.
+
+`com.blackbuild.annodocimal.plugin` is replaced without a shim. Plugin implementation class names and task-action
+methods are not supported Java APIs.
+
+## Current public-type classification
+
+### Annotations artifact
+
+| Current public type | Classification | 1.0 disposition |
+|---|---|---|
+| `com.blackbuild.annodocimal.annotations.AnnoDoc` | supported | Retain the annotation and `value()` carrier contract. |
+| `com.blackbuild.annodocimal.annotations.InlineJavadocs` | supported | Retain the marker; remove or hide its public suffix constant. |
+
+### APT artifact
+
+| Current public type | Classification | 1.0 disposition |
+|---|---|---|
+| `com.blackbuild.annodocimal.ast.AnnoDocimalAnnotationProcessor` | implementation-only | Retain only as the service provider; no construction/subclassing compatibility. |
+| `com.blackbuild.annodocimal.ast.JavadocPropertiesBuilder` | implementation-only | Hide or replace behind processor behavior. |
+
+### AST artifact
+
+| Current public type | Classification | 1.0 disposition |
+|---|---|---|
+| `com.blackbuild.annodocimal.ast.extractor.ASTExtractor` | implementation-only | Replace with `AstDocumentation.extractExact`; do not retain its names, metadata constants, string fallback, or cache surface. |
+| `com.blackbuild.annodocimal.ast.extractor.ClassDocExtractor` | implementation-only | Hide behind exact extraction. |
+| `com.blackbuild.annodocimal.ast.extractor.InheritanceUtil` | implementation-only | Remove from 1.0 API; issue #10 owns later resolved extraction. |
+| `com.blackbuild.annodocimal.ast.parser.SourceExtractor` | implementation-only | Keep source capture separate from transformation-author extraction. |
+| `com.blackbuild.annodocimal.ast.parser.AbstractSourceExtractor` | implementation-only | Hide implementation inheritance. |
+| `com.blackbuild.annodocimal.ast.parser.SourceExtractorFactory` | implementation-only | Hide implementation selection. |
+| `com.blackbuild.annodocimal.ast.parser.GroovyVersionHandler` | implementation-only | Hide Groovy-version adaptation. |
+| `com.blackbuild.annodocimal.ast.parser.groovy3.Groovy3SourceExtractor` | implementation-only | Hide Groovy-generation implementation. |
+| `com.blackbuild.annodocimal.ast.formatting.DocText` | implementation-only | Replace with immutable semantic `Documentation`; no raw-text compatibility. |
+| `com.blackbuild.annodocimal.ast.formatting.DocBuilder` | implementation-only | Replace with `Documentation.Builder`; no shim. |
+| `com.blackbuild.annodocimal.ast.formatting.AbstractDocBuilder` | implementation-only | Remove implementation inheritance. |
+| `com.blackbuild.annodocimal.ast.formatting.JavadocDocBuilder` | implementation-only | Replace with `Documentation.Builder`; no shim. |
+| `com.blackbuild.annodocimal.ast.formatting.TemplateHandler` | implementation-only | Remove from API; issue #51 selects the supported authoring language. |
+| `com.blackbuild.annodocimal.ast.formatting.JavaDocUtil` | implementation-only | Replace declaration-link capability with `AstDocumentation.referenceTo`. |
+| `com.blackbuild.annodocimal.ast.formatting.AnnoDocUtil` | implementation-only | Replace attachment capability with `AstDocumentation.attach` and `attachText`. |
+| `com.blackbuild.annodocimal.ast.InlineJavadocsVisitor` | implementation-only | Hide capture visitor and metadata/cache technology. |
+| `com.blackbuild.annodocimal.ast.InlineJavadocsTransformation` | implementation-only | Retain only as local transformation packaging behavior. |
+
+### Global AST artifact
+
+| Current public type | Classification | 1.0 disposition |
+|---|---|---|
+| `com.blackbuild.annodocimal.global.ast.InlineJavadocsGlobalTransformation` | implementation-only | Retain only as the owning artifact's service provider adapter. |
+
+### Generator artifact: AnnoDocimal-owned types
+
+| Current public type | Classification | 1.0 disposition |
+|---|---|---|
+| `com.blackbuild.annodocimal.generator.AnnoDocGenerator` | implementation-only | Replace with `SourceProjector`; no shim. |
+| `com.blackbuild.annodocimal.generator.JavaPoetClassVisitor` | implementation-only | Hide projection technology. |
+| `com.blackbuild.annodocimal.generator.MemberAnnotationVisitor` | implementation-only | Hide annotation-reading technology. |
+| `com.blackbuild.annodocimal.generator.MemberAnnotationVisitor.Javadoc` | implementation-only | Hide annotation-reading technology. |
+| `com.blackbuild.annodocimal.generator.MemberAnnotationVisitor.MemberArray` | implementation-only | Hide annotation-reading technology. |
+| `com.blackbuild.annodocimal.generator.MemberAnnotationVisitor.Regular` | implementation-only | Hide annotation-reading technology. |
+| `com.blackbuild.annodocimal.generator.SpecConverter` | implementation-only | Hide JavaPoet conversion. |
+| `com.blackbuild.annodocimal.generator.TypeConversion` | implementation-only | Hide signature/type conversion. |
+| `com.blackbuild.annodocimal.generator.TypeFilter` | implementation-only | Replace accidental filtering with `ProjectionPolicy`. |
+
+Every public relocated type in the current generator shadow JAR is implementation-only with the disposition **remain
+relocated/hidden as required by implementation, but never enter the supported baseline**:
+
+```text
+shadow.asm.AnnotationVisitor
+shadow.asm.Attribute
+shadow.asm.ByteVector
+shadow.asm.ClassReader
+shadow.asm.ClassTooLargeException
+shadow.asm.ClassVisitor
+shadow.asm.ClassWriter
+shadow.asm.ConstantDynamic
+shadow.asm.FieldVisitor
+shadow.asm.Handle
+shadow.asm.Label
+shadow.asm.MethodTooLargeException
+shadow.asm.MethodVisitor
+shadow.asm.ModuleVisitor
+shadow.asm.Opcodes
+shadow.asm.RecordComponentVisitor
+shadow.asm.Type
+shadow.asm.TypePath
+shadow.asm.TypeReference
+shadow.asm.signature.SignatureReader
+shadow.asm.signature.SignatureVisitor
+shadow.asm.signature.SignatureWriter
+shadow.asm.tree.AbstractInsnNode
+shadow.asm.tree.AnnotationNode
+shadow.asm.tree.ClassNode
+shadow.asm.tree.FieldInsnNode
+shadow.asm.tree.FieldNode
+shadow.asm.tree.FrameNode
+shadow.asm.tree.IincInsnNode
+shadow.asm.tree.InnerClassNode
+shadow.asm.tree.InsnList
+shadow.asm.tree.InsnNode
+shadow.asm.tree.IntInsnNode
+shadow.asm.tree.InvokeDynamicInsnNode
+shadow.asm.tree.JumpInsnNode
+shadow.asm.tree.LabelNode
+shadow.asm.tree.LdcInsnNode
+shadow.asm.tree.LineNumberNode
+shadow.asm.tree.LocalVariableAnnotationNode
+shadow.asm.tree.LocalVariableNode
+shadow.asm.tree.LookupSwitchInsnNode
+shadow.asm.tree.MethodInsnNode
+shadow.asm.tree.MethodNode
+shadow.asm.tree.ModuleExportNode
+shadow.asm.tree.ModuleNode
+shadow.asm.tree.ModuleOpenNode
+shadow.asm.tree.ModuleProvideNode
+shadow.asm.tree.ModuleRequireNode
+shadow.asm.tree.MultiANewArrayInsnNode
+shadow.asm.tree.ParameterNode
+shadow.asm.tree.RecordComponentNode
+shadow.asm.tree.TableSwitchInsnNode
+shadow.asm.tree.TryCatchBlockNode
+shadow.asm.tree.TypeAnnotationNode
+shadow.asm.tree.TypeInsnNode
+shadow.asm.tree.UnsupportedClassVersionException
+shadow.asm.tree.VarInsnNode
+shadow.javapoet.AnnotationSpec
+shadow.javapoet.AnnotationSpec.Builder
+shadow.javapoet.ArrayTypeName
+shadow.javapoet.ClassName
+shadow.javapoet.CodeBlock
+shadow.javapoet.CodeBlock.Builder
+shadow.javapoet.FieldSpec
+shadow.javapoet.FieldSpec.Builder
+shadow.javapoet.JavaFile
+shadow.javapoet.JavaFile.Builder
+shadow.javapoet.MethodSpec
+shadow.javapoet.MethodSpec.Builder
+shadow.javapoet.NameAllocator
+shadow.javapoet.ParameterSpec
+shadow.javapoet.ParameterSpec.Builder
+shadow.javapoet.ParameterizedTypeName
+shadow.javapoet.TypeName
+shadow.javapoet.TypeSpec
+shadow.javapoet.TypeSpec.Builder
+shadow.javapoet.TypeSpec.Kind
+shadow.javapoet.TypeVariableName
+shadow.javapoet.WildcardTypeName
+```
+
+### Gradle plugin artifact
+
+| Current public type | Classification | 1.0 disposition |
+|---|---|---|
+| `com.blackbuild.annodocimal.plugin.CreateClassStubs` | implementation-only | Replace with supported `SourceProjectionTask`; no shim. |
+| `com.blackbuild.annodocimal.plugin.AnnoDocimalBasePlugin` | implementation-only | Retain as implementation of the supported base plugin ID. |
+| `com.blackbuild.annodocimal.plugin.AnnoDocimalPlugin` | implementation-only | Replace with the implementation of the supported Groovy plugin ID. |
+
+## Mechanical compatibility baseline
+
+The human classification above remains authoritative. Implementation must produce one machine-readable allowlist and one
+generated signature snapshot per Java-facing artifact, checked into version control. The build derives each snapshot from
+the built artifact filtered by that artifact's allowlist; a snapshot is never produced by accepting every public class.
+
+The snapshots include supported top-level and nested types, constructors, methods, fields, enum constants, annotation
+members and defaults, generic signatures, superclass and interface relationships, visibility, and compatibility-relevant
+annotations. They exclude implementation-only types, provider names, shaded packages, task actions, and plugin
+implementation classes even when those remain public in bytecode.
+
+The compatibility check compares both source and binary contracts against the most recent released baseline and fails on
+incompatible removal, visibility reduction, descriptor or generic-signature change, superclass/interface change, or
+compatibility-relevant annotation change. A compatible addition still requires an intentional allowlist update and
+review; the tool must not silently widen the supported surface. An accepted incompatibility requires a release-facing
+rationale and corresponding migration documentation.
+
+Behavioral and data contracts are verified separately: annotation-processing and AST service discovery, protocol
+resources, exact attachment/extraction behavior, projection semantics and determinism, task cacheability and managed
+output, plugin-ID behavior, and JPMS module names are not reduced to JVM signatures. The module names delivered by issue
+#36 remain stable and the baseline must not reopen KlumAST #455's separate multi-Groovy build decision.
+
+Issue #51 must resolve the provisional builder slot before the 1.0 snapshots are locked. Issues #38, #39, and #35 add the
+new supported types and members; the compatibility-baseline work then generates and verifies the initial snapshots from
+this record rather than from the 0.x public surface.

--- a/docs/implementation/1.0-issue-curation-plan.md
+++ b/docs/implementation/1.0-issue-curation-plan.md
@@ -6,7 +6,8 @@ listed existing issues, and closed the confirmed superseded items. Future issue 
 authorization under the repository policy.
 
 During the issue #37 grilling on 2026-07-18, Stephan separately authorized creation of AnnoDocimal #51 and KlumAST #489
-for the deferred authoring-language decision. No existing issue, label, milestone, tracker body, or comment was changed.
+for the coordinated authoring-language decision. Both are now complete. API-1 made no further GitHub mutation; the later
+#51 delivery updated tracker #47 externally to show that prerequisite complete.
 
 KlumAST issue #455 remains a separate cross-repository multi-Groovy redesign. AnnoDocimal 1.0 is a hard prerequisite for
 KlumAST 4.0, but KlumAST issue and release-plan mutations belong in that repository.
@@ -34,12 +35,14 @@ GitHub issue #47 tracks release narrative, dependency order, and gate visibility
 issues own their acceptance criteria:
 
 1. **#37 — Finalize the 1.0 supported API.** The grilling classified all current public types, designed the independent
-   facade/value/projection/Gradle contracts, resolved #18 naming, and specified the clean migration and mechanical
-   baseline rules. The one authoring-language slot is explicitly delegated to #51.
-2. **#51 — Stabilize the documentation authoring/template language.** Decide the final builder authoring members with
-   KlumAST #489, including code blocks, possible paragraph kinds, template substitution/failure behavior, and migration.
-3. **#38 — Implement the curated transformation-author API.** The non-authoring contract is decided; final completion is
-   gated by #51. Keep issue #30's structured carrier schema out of scope.
+   facade/value/projection/Gradle contracts, resolved #18 naming, incorporated completed #51/#489, and specified the
+   clean migration and mechanical baseline rules. No public type remains provisional.
+2. **#51 — Stabilize the documentation authoring/template language (complete).** ADR 0057 records the jointly confirmed
+   prose/code block, composition, template, link, failure, and migration semantics; KlumAST #489 is also complete.
+3. **#38 — Implement the curated transformation-author API.** The full contract is decided and agent-ready. Preserve
+   ADR 0057's language, apply ADR 0058's optional accessors, strict null handling, explicit clear methods, uniform value
+   semantics, typed template map, and alias removals, then refresh the scoped authoring baseline. Keep issue #30's
+   structured carrier schema out of scope.
 4. **#39 — Implement the narrow projection API and policy.** The service, policy, inclusion, closure, output, error, and
    clean `AnnoDocGenerator` migration contracts are fully decided and ready for implementation briefing.
 5. **#41 — Build the projection contract suite.** Assert deterministic output and recompile representative Java/Groovy
@@ -66,7 +69,7 @@ reusing it (ADR 0052).
 
 ## Dependency order
 
-1. Use the issue #37 records to implement #39 independently; resolve #51/#489 before locking #38's authoring surface.
+1. Use the completed issue #37/#51 records to implement #38 and #39 independently.
 2. Implement the transformation and projection APIs/policy; #9, #19, #33, and the capture suite may progress in parallel
    where their confirmed contracts are independent.
 3. Finish #35 against the supported projection service; retain completed #36 without deciding KlumAST #455.
@@ -84,8 +87,8 @@ reusing it (ADR 0052).
 
 ## Applied GitHub state
 
-- Milestone `1.0` and tracker #47 remain unchanged by the issue #37 grilling; historical `initial-release` is closed.
-- Issue #36 is closed as completed. Newly created #51 and cross-repository #489 are intentionally unlabelled pending a
-  separately authorized triage pass.
+- Milestone `1.0` remains unchanged by API-1; historical `initial-release` is closed. Tracker #47 was later updated
+  outside API-1 to mark #51 complete.
+- Issues #36 and #51 and cross-repository KlumAST #489 are closed as completed.
 - Issues #18, #22, and #25 are closed with the confirmed rationale.
 - Canonical category/state labels are present and every curated issue has exactly one of each.

--- a/docs/implementation/1.0-issue-curation-plan.md
+++ b/docs/implementation/1.0-issue-curation-plan.md
@@ -5,6 +5,9 @@ application on 2026-07-16. That pass created the `1.0` milestone and tracker, cr
 listed existing issues, and closed the confirmed superseded items. Future issue transitions still require evidence and
 authorization under the repository policy.
 
+During the issue #37 grilling on 2026-07-18, Stephan separately authorized creation of AnnoDocimal #51 and KlumAST #489
+for the deferred authoring-language decision. No existing issue, label, milestone, tracker body, or comment was changed.
+
 KlumAST issue #455 remains a separate cross-repository multi-Groovy redesign. AnnoDocimal 1.0 is a hard prerequisite for
 KlumAST 4.0, but KlumAST issue and release-plan mutations belong in that repository.
 
@@ -23,31 +26,33 @@ KlumAST 4.0, but KlumAST issue and release-plan mutations belong in that reposit
 | #32 | Gate | Add an AnnoDocimal-native inherited-generics fixture and compile the projected Java; include it in the broader projection contract suite. |
 | #33 | Gate | Normalize annotation-member order and prove identical output across Groovy 3, 4, and 5. |
 | #35 | Gate | Implement the reusable cacheable task contract and verify it with TestKit over the supported Gradle range. |
-| #36 | Gate | Publish stable module names, move global service provision behind the owning adapter, and verify module-path behavior. |
+| #36 | Completed gate | Delivered stable module names and the owning global-service adapter through merged PR #50. |
 
 ## New 1.0 work items
 
 GitHub issue #47 tracks release narrative, dependency order, and gate visibility. These independently executable linked
 issues own their acceptance criteria:
 
-1. **#37 — Finalize the 1.0 supported API.** Run the mandatory grilling; classify every public type; design the curated
-   transformation-author facade/value model and narrow projection service; resolve #18 naming; define the clean 0.x
-   migration; establish the API-compatibility baseline.
-2. **#38 — Implement the curated transformation-author API.** Migrate known consumers without freezing parser, visitor,
-   metadata-cache, or mutable-builder implementation types. Keep issue #30's structured carrier schema out of scope.
-3. **#39 — Implement the narrow projection API and policy.** Support text and managed output, define declaration inclusion and
-   signature closure, keep top-level class-file selection in callers, and document any retained legacy entry points.
-4. **#41 — Build the projection contract suite.** Assert deterministic output and recompile representative Java/Groovy
+1. **#37 — Finalize the 1.0 supported API.** The grilling classified all current public types, designed the independent
+   facade/value/projection/Gradle contracts, resolved #18 naming, and specified the clean migration and mechanical
+   baseline rules. The one authoring-language slot is explicitly delegated to #51.
+2. **#51 — Stabilize the documentation authoring/template language.** Decide the final builder authoring members with
+   KlumAST #489, including code blocks, possible paragraph kinds, template substitution/failure behavior, and migration.
+3. **#38 — Implement the curated transformation-author API.** The non-authoring contract is decided; final completion is
+   gated by #51. Keep issue #30's structured carrier schema out of scope.
+4. **#39 — Implement the narrow projection API and policy.** The service, policy, inclusion, closure, output, error, and
+   clean `AnnoDocGenerator` migration contracts are fully decided and ready for implementation briefing.
+5. **#41 — Build the projection contract suite.** Assert deterministic output and recompile representative Java/Groovy
    projections across Groovy 3/4/5, incorporating #32 and #33.
-5. **#43 — Build the capture conformance suite.** Compare observable normalized results from Java APT, local Groovy capture,
+6. **#43 — Build the capture conformance suite.** Compare observable normalized results from Java APT, local Groovy capture,
    and global Groovy capture, including service discovery.
-6. **#40 — Complete 1.0 documentation and migration.** Cover artifact/plugin choice, capture modes, supported API,
+7. **#40 — Complete 1.0 documentation and migration.** Cover artifact/plugin choice, capture modes, supported API,
    compatibility, protocol, projection semantics, release notes, and 0.x migration; historical backfill is separate.
-7. **#44 — Audit the publication contract.** Smoke-test all six artifacts and both plugin markers from a clean local repository,
+8. **#44 — Audit the publication contract.** Smoke-test all six artifacts and the base/Groovy plugin markers from a clean local repository,
    including metadata, dependencies, signatures, sources/Javadocs, shading, descriptors, and consumer resolution.
-8. **#46 — Expose compatibility evidence in CI.** Make Java 17, Groovy 3/4/5, minimum/current Gradle, configuration cache, and
+9. **#46 — Expose compatibility evidence in CI.** Make Java 17, Groovy 3/4/5, minimum/current Gradle, configuration cache, and
    publication smoke evidence identifiable and diagnosable.
-9. **#45 — Document and rehearse the release procedure.** Cover version/tag derivation, Maven Central staging, Plugin Portal,
+10. **#45 — Document and rehearse the release procedure.** Cover version/tag derivation, Maven Central staging, Plugin Portal,
    changelog/GitHub Release synchronization, verification, and recovery.
 
 Issue #37 is a human-decision predecessor. The tracker coordinates it and the implementation issues without
@@ -61,10 +66,10 @@ reusing it (ADR 0052).
 
 ## Dependency order
 
-1. Finalize the supported API and migration policy before implementing the two public facades.
+1. Use the issue #37 records to implement #39 independently; resolve #51/#489 before locking #38's authoring surface.
 2. Implement the transformation and projection APIs/policy; #9, #19, #33, and the capture suite may progress in parallel
    where their confirmed contracts are independent.
-3. Finish #35 against the supported projection service and finish #36 without deciding KlumAST #455.
+3. Finish #35 against the supported projection service; retain completed #36 without deciding KlumAST #455.
 4. Complete projection/capture contract evidence, then lock the mechanical API baseline.
 5. Finish docs, publication smoke tests, and explicit CI evidence against the final contracts.
 6. Rehearse the release runbook and release AnnoDocimal 1.0 before KlumAST 4.0.
@@ -79,8 +84,8 @@ reusing it (ADR 0052).
 
 ## Applied GitHub state
 
-- Milestone `1.0` is open with 16 gates/tracker issues; historical `initial-release` is closed.
-- Issue #36 is `ready-for-agent`; #37, #45, and #47 are `ready-for-human`; unresolved implementation/design gates remain
-  `needs-triage`.
+- Milestone `1.0` and tracker #47 remain unchanged by the issue #37 grilling; historical `initial-release` is closed.
+- Issue #36 is closed as completed. Newly created #51 and cross-repository #489 are intentionally unlabelled pending a
+  separately authorized triage pass.
 - Issues #18, #22, and #25 are closed with the confirmed rationale.
 - Canonical category/state labels are present and every curated issue has exactly one of each.

--- a/docs/implementation/1.0-release-plan.md
+++ b/docs/implementation/1.0-release-plan.md
@@ -13,16 +13,20 @@ The tracker and every hard gate belong to a dedicated GitHub `1.0` milestone; la
 
 ## Confirmed gates
 
-- Run a dedicated API grilling session that classifies every published public type, finalizes each artifact's supported-
-  API allowlist, establishes the first mechanical source/binary compatibility baseline, and resolves issue #18's
-  remaining extractor/facade naming concern without implementing its obsolete merge proposal (ADRs 0026 and 0036).
+- Apply the issue #37 API-grilling decisions: the per-artifact public-type classification and allowlists are recorded,
+  issue #18's naming concern resolves to `AstDocumentation.extractExact`, and implementation must generate the first
+  mechanical source/binary compatibility snapshots from the human allowlist rather than all public bytecode (ADRs 0026,
+  0036, and 0053-0055).
+- Stabilize the remaining documentation authoring/template language through AnnoDocimal #51 and KlumAST #489 before the
+  transformation-author baseline is locked. This includes code blocks, possible paragraph kinds, substitution/failure
+  semantics, and the final `Documentation.Builder` authoring members (ADR 0056).
 - Design and deliver the curated transformation-author facade and documentation value model from that grilling, mapping
   known consumers and providing deliberate shims or migration for existing helpers without pulling issue #30's
   structured carrier schema into 1.0 (ADR 0047).
 - Resolve issue #35 and verify the reusable source-projection task's invalidation, stale-output, up-to-date, build-cache,
   configuration-cache, and supported-Gradle-range behavior with TestKit (ADR 0028).
-- Resolve issue #36 by publishing the confirmed stable module names, moving global AST service provision behind the
-  owning artifact's adapter, and verifying module-path/service behavior (ADR 0029).
+- Retain the stable module names and owning global-AST provider adapter delivered for issue #36 by merged PR #50; do not
+  reopen KlumAST #455's separate multi-Groovy decision (ADR 0029).
 - Resolve issue #32 with an AnnoDocimal-native inherited-generics regression fixture and compile the projected Java
   source to prove that supported generic API shapes remain valid (ADR 0031).
 - Resolve issue #33 by normalizing annotation-member ordering and verifying identical deterministic projections across
@@ -32,7 +36,8 @@ The tracker and every hard gate belong to a dedicated GitHub `1.0` milestone; la
 - Re-scope issue #19 from its Groovy-2-era checklist and complete runtime GroovyDoc interoperability, duplicate avoidance,
   generator recognition, and deterministic carrier precedence across Groovy 3, 4, and 5 (ADR 0035).
 - Complete repository-owned README/docs, Javadocs, release notes, compatibility reference, supported-API documentation,
-  projection semantics, and 0.x-to-1.0 migration guidance for all artifacts and both plugins (ADR 0040).
+  projection semantics, and 0.x-to-1.0 migration guidance for all artifacts and the supported base/Groovy plugin pair
+  (ADR 0040).
 - Prefer a clean cut from provisional 0.x source APIs: migrate KlumAST, document the path, and retain shims only when
   independently useful and cheap. Do not apply this rule to separately confirmed persisted-protocol compatibility
   (ADR 0049).
@@ -79,5 +84,6 @@ The tracker and every hard gate belong to a dedicated GitHub `1.0` milestone; la
 
 ## Issue tracking
 
-Tracker #47 links every hard gate. New API, contract-suite, documentation, publication, CI, and runbook work is tracked
-in #37–#41 and #43–#46; existing gates remain #9, #19, #32, #33, #35, and #36.
+Tracker #47 links the curated hard gates. New API, contract-suite, documentation, publication, CI, and runbook work is
+tracked in #37–#41 and #43–#46; authoring-language follow-up #51 is an additional 1.0 prerequisite coordinated with
+KlumAST #489. Existing unresolved gates remain #9, #19, #32, #33, and #35; issue #36 is complete.

--- a/docs/implementation/1.0-release-plan.md
+++ b/docs/implementation/1.0-release-plan.md
@@ -16,10 +16,10 @@ The tracker and every hard gate belong to a dedicated GitHub `1.0` milestone; la
 - Apply the issue #37 API-grilling decisions: the per-artifact public-type classification and allowlists are recorded,
   issue #18's naming concern resolves to `AstDocumentation.extractExact`, and implementation must generate the first
   mechanical source/binary compatibility snapshots from the human allowlist rather than all public bytecode (ADRs 0026,
-  0036, and 0053-0055).
-- Stabilize the remaining documentation authoring/template language through AnnoDocimal #51 and KlumAST #489 before the
-  transformation-author baseline is locked. This includes code blocks, possible paragraph kinds, substitution/failure
-  semantics, and the final `Documentation.Builder` authoring members (ADR 0056).
+  0036, 0053-0055, and 0058).
+- Retain the documentation authoring/template language completed through AnnoDocimal #51 and KlumAST #489: first-class
+  prose/code blocks, deliberate composition, named single-pass templates, first-class links, and contextual failures.
+  Apply ADR 0058's Java-shape corrections before locking the transformation-author baseline (ADRs 0056-0058).
 - Design and deliver the curated transformation-author facade and documentation value model from that grilling, mapping
   known consumers and providing deliberate shims or migration for existing helpers without pulling issue #30's
   structured carrier schema into 1.0 (ADR 0047).
@@ -85,5 +85,5 @@ The tracker and every hard gate belong to a dedicated GitHub `1.0` milestone; la
 ## Issue tracking
 
 Tracker #47 links the curated hard gates. New API, contract-suite, documentation, publication, CI, and runbook work is
-tracked in #37–#41 and #43–#46; authoring-language follow-up #51 is an additional 1.0 prerequisite coordinated with
-KlumAST #489. Existing unresolved gates remain #9, #19, #32, #33, and #35; issue #36 is complete.
+tracked in #37–#41 and #43–#46. Authoring-language follow-up #51 and KlumAST #489 are complete. Existing unresolved gates
+remain #9, #19, #32, #33, and #35; issue #36 is complete.

--- a/docs/implementation/architecture-and-agent-baseline.md
+++ b/docs/implementation/architecture-and-agent-baseline.md
@@ -1,10 +1,10 @@
 # Architecture and agent baseline
 
-Date: 2026-07-16; API-grilling refinement: 2026-07-18
+Date: 2026-07-16; API-grilling refinement: 2026-07-19
 
 This plan records repository-native evidence and confirmed decisions. It is not an API or build implementation plan.
 After the architecture grilling, Stephan separately authorized the GitHub curation recorded in the issue-curation plan.
-The later issue #37 decisions in ADRs 0053-0056 and `docs/api/1.0-supported-api.md` supersede provisional API names and
+The later issue #37/#51 decisions in ADRs 0053-0058 and `docs/api/1.0-supported-api.md` supersede provisional API names and
 plugin-ID details in this baseline where they differ.
 
 ## Confirmed decisions
@@ -34,11 +34,11 @@ Recorded in ADR 0002.
 ### API compatibility boundary
 
 Source and binary compatibility are governed by an explicit supported-API allowlist for each contract family. A type is
-not supported merely because it is public or included in a published JAR. Issue #37 classified all 113 current public
-types and defined the intended 1.0 allowlists in `docs/api/1.0-supported-api.md`; only the not-yet-final authoring members
-of `Documentation.Builder` remain provisional under issue #51.
+not supported merely because it is public or included in a published JAR. Issue #37 classified the original 113 public
+types and the seven authoring types subsequently added by issue #51, then defined the intended 1.0 allowlists in
+`docs/api/1.0-supported-api.md`. No public type remains provisional; ADR 0058 lists pre-baseline member corrections.
 
-Recorded in ADRs 0003, 0026, and 0053-0056.
+Recorded in ADRs 0003, 0026, and 0053-0058.
 
 ### Documentation protocol ownership
 
@@ -65,12 +65,12 @@ Recorded in ADRs 0005 and 0053.
 
 ### Curated transformation-author surface
 
-The supported transformation-author API is the curated facade and semantic value model in ADR 0053. Current extractors,
-builders, parsers, template handlers, visitors, caches, and utility classes are implementation-only or replaced without
-shims. Issue #30's structured carrier schema remains separate. AnnoDocimal #51 and KlumAST #489 must settle the final
-authoring/template members before 1.0.
+The supported transformation-author API is the curated facade and semantic value model in ADRs 0053, 0057, and 0058.
+Current extractors, builders, parsers, template handlers, visitors, caches, and utility classes are implementation-only
+or replaced without shims. Issue #30's structured carrier schema remains separate. AnnoDocimal #51 and KlumAST #489
+completed the final authoring-language decision; issue #38 applies the remaining pre-baseline Java-shape corrections.
 
-Recorded in ADRs 0006, 0049, 0053, and 0056.
+Recorded in ADRs 0006, 0049, and 0053-0058.
 
 ### Source-projection API boundary
 
@@ -308,9 +308,9 @@ Each published artifact receives a mechanical compatibility baseline for its exp
 not accidentally freeze every public implementation type, and accepted incompatibilities require release-facing
 rationale.
 
-Issue #37 completed the public-type classification, finalized every independent allowlist, and specified how the human
-allowlist feeds per-artifact machine-readable source/binary signature snapshots. Issue #51 must resolve the one provisional
-authoring-language slot before implementation locks the first baseline.
+Issue #37 completed the public-type classification, finalized every allowlist, and specified how the human allowlist
+feeds per-artifact machine-readable source/binary signature snapshots. Issue #51 resolved the authoring-language slot;
+issue #38 applies ADR 0058's corrections before implementation locks the first full baseline.
 
 Recorded in ADR 0026 and `docs/api/1.0-supported-api.md`.
 
@@ -476,10 +476,11 @@ Recorded in ADR 0046 and the 1.0 release plan.
 ### Curated transformation-author API release gate
 
 Delivery of `AstDocumentation`, immutable `Documentation`, and its builder blocks 1.0. Issue #37 designed the facade,
-mapped consumers, classified current helpers, and selected clean migration without issue #30's carrier schema. Issue #38
-owns implementation; issue #51 and KlumAST #489 must settle its final authoring-language members.
+mapped consumers, classified current helpers, and selected clean migration without issue #30's carrier schema. Issue #51
+and KlumAST #489 completed the language. Issue #38 owns the remaining implementation and ADR 0058 corrections and is
+decision-ready.
 
-Recorded in ADRs 0047, 0053, and 0056 and the 1.0 release plan.
+Recorded in ADRs 0047 and 0053-0058 and the 1.0 release plan.
 
 ### Narrow source-projection API release gate
 
@@ -505,8 +506,8 @@ issues retain their own acceptance criteria, and the mandatory API grilling is a
 Recorded in ADR 0050 and the issue-curation plan.
 
 The tracker and originally curated hard-gate issues use a dedicated GitHub `1.0` milestone for queryable progress.
-AnnoDocimal #51 is an additional authorized 1.0 prerequisite but its tracker/milestone/label curation remains unchanged
-until separately authorized. Post-1.0 and 2.0 work remains outside the milestone. Recorded in ADRs 0051 and 0056.
+AnnoDocimal #51 was an additional authorized prerequisite and is complete; tracker #47 now records that completion.
+Post-1.0 and 2.0 work remains outside the milestone. Recorded in ADRs 0051 and 0056.
 
 The completed historical `initial-release` milestone is closed rather than renamed or reused. Recorded in ADR 0052.
 
@@ -561,10 +562,8 @@ wiring currently belong to the consumer.
 
 ## Architectural pressure points requiring decisions
 
-1. The authoring/template language in AnnoDocimal #51 and KlumAST #489, including code blocks, possible paragraph kinds,
-   substitution/failure semantics, and the final builder-member allowlist.
-2. The measured minimum supported Gradle version for issue #35's TestKit matrix.
-3. Long-term shared documentation publication and branding mechanics.
+1. The measured minimum supported Gradle version for issue #35's TestKit matrix.
+2. Long-term shared documentation publication and branding mechanics.
 
 Deferred protocol evolution: issue #30 may introduce structured documentation annotations and targets a future 2.0
 release. Keep it separate from the 1.0 baseline and do not infer its design from the existing issue stub.
@@ -580,6 +579,6 @@ decision and coordinated migration, not a repository-local build simplification.
 
 The authorized curation pass created tracker #47 and gate issues #37–#41 and #43–#46. Existing 1.0 gates #9, #19,
 #32, #33, #35, and #36 were curated into milestone `1.0`; #36 was later completed through merged PR #50. Issues #18,
-#22, and #25 were closed with confirmed rationale. The issue #37 session separately created unlabelled AnnoDocimal #51
-and KlumAST #489 without changing the tracker or other existing issues. Detailed scope, dependency order, and non-gates
-live in `docs/implementation/1.0-issue-curation-plan.md`.
+#22, and #25 were closed with confirmed rationale. The issue #37 session separately created AnnoDocimal #51 and KlumAST
+#489; both are complete, and tracker #47 was updated outside API-1 to reflect #51. Detailed scope, dependency order, and
+non-gates live in `docs/implementation/1.0-issue-curation-plan.md`.

--- a/docs/implementation/architecture-and-agent-baseline.md
+++ b/docs/implementation/architecture-and-agent-baseline.md
@@ -1,9 +1,11 @@
 # Architecture and agent baseline
 
-Date: 2026-07-16
+Date: 2026-07-16; API-grilling refinement: 2026-07-18
 
 This plan records repository-native evidence and confirmed decisions. It is not an API or build implementation plan.
 After the architecture grilling, Stephan separately authorized the GitHub curation recorded in the issue-curation plan.
+The later issue #37 decisions in ADRs 0053-0056 and `docs/api/1.0-supported-api.md` supersede provisional API names and
+plugin-ID details in this baseline where they differ.
 
 ## Confirmed decisions
 
@@ -32,12 +34,11 @@ Recorded in ADR 0002.
 ### API compatibility boundary
 
 Source and binary compatibility are governed by an explicit supported-API allowlist for each contract family. A type is
-not supported merely because it is public or included in a published JAR. Existing public types remain provisional until
-classified, and internalizing them requires an appropriately versioned change.
+not supported merely because it is public or included in a published JAR. Issue #37 classified all 113 current public
+types and defined the intended 1.0 allowlists in `docs/api/1.0-supported-api.md`; only the not-yet-final authoring members
+of `Documentation.Builder` remain provisional under issue #51.
 
-This decision changes policy only; no current package, visibility, artifact, or dependency is changed in this session.
-
-Recorded in ADR 0003.
+Recorded in ADRs 0003, 0026, and 0053-0056.
 
 ### Documentation protocol ownership
 
@@ -55,44 +56,30 @@ Recorded in ADR 0004.
 
 ### Transformation-author API
 
-Transformation authors receive a first-class supported API for these capabilities:
+Transformation authors receive the supported `AstDocumentation` facade for exact extraction, semantic attachment,
+normalized-text attachment, and declaration references, plus immutable `Documentation` and its transient builder.
+Source-position parsing, Groovy-version adaptation, visitors, metadata caching, and transformation machinery are not
+part of that contract merely because current implementation types are public.
 
-- extract documentation from compiler model elements;
-- inspect documentation as a structured model;
-- build, rewrite, and template documentation;
-- attach documentation to generated declarations.
-
-Source-position parsing, Groovy-version adaptation, visitors, metadata caching, and transformation machinery are not part
-of that contract merely because current implementation types are public. The concrete type allowlist remains to be
-classified.
-
-Recorded in ADR 0005.
+Recorded in ADRs 0005 and 0053.
 
 ### Curated transformation-author surface
 
-The eventual supported transformation-author API will be a curated facade and documentation value model. Current helpers
-are evidence for required capabilities, but remain provisional until a future design:
+The supported transformation-author API is the curated facade and semantic value model in ADR 0053. Current extractors,
+builders, parsers, template handlers, visitors, caches, and utility classes are implementation-only or replaced without
+shims. Issue #30's structured carrier schema remains separate. AnnoDocimal #51 and KlumAST #489 must settle the final
+authoring/template members before 1.0.
 
-- maps each helper capability to the curated contract;
-- identifies types or methods worth retaining directly;
-- defines compatibility shims or migration for existing consumers;
-- coordinates the value model with issue #30's possible structured annotation protocol.
-
-This baseline does not design or implement that facade and does not remove current helpers.
-
-Recorded in ADR 0006.
+Recorded in ADRs 0006, 0049, 0053, and 0056.
 
 ### Source-projection API boundary
 
-The generator contract is a narrow, implementation-neutral service that projects a compiled class to Java text or an
-output location. Its supported behavior is expressed as source-projection fidelity, not exposure of ASM, JavaPoet, visitor,
-signature-parser, type-conversion, or shaded implementation types.
+The generator contract is the final, thread-safe `SourceProjector`, immutable `ProjectionPolicy` and builder,
+`DeclarationVisibility`, and `SourceProjectionException`. It projects one caller-selected top-level class to text or a
+managed file without exposing ASM, JavaPoet, visitors, signature parsers, type conversion, or shaded types.
+`AnnoDocGenerator` is replaced without a shim.
 
-The current `AnnoDocGenerator` entry points are evidence for the service but are not redesigned in this baseline. Issue
-#25 or another major implementation-technology switch must be possible without leaking the replacement library into the
-supported API.
-
-Recorded in ADR 0007.
+Recorded in ADRs 0007 and 0054.
 
 ### Source-projection fidelity
 
@@ -108,45 +95,35 @@ Recorded in ADR 0008.
 
 ### Projection inclusion policy
 
-The new projection service receives an explicit declaration-inclusion policy covering visibility, nested types, synthetic
-members, and Groovy-generated artifacts. It also retains declarations required to represent selected signatures.
+`ProjectionPolicy.documentation()` includes public/protected declarations and named member types, excludes synthetic and
+Groovy-runtime scaffolding, and always applies signature closure. The builder exposes only implementation-neutral
+visibility, nested, synthetic, and Groovy-runtime controls. Top-level class-file selection remains a consuming-build or
+Gradle-task concern; annotation-presence filtering is a future additive feature.
 
-Top-level class-file selection is a consuming-build or Gradle-task concern. Existing `AnnoDocGenerator` entry points keep
-their legacy behavior until a separately designed and versioned migration. This baseline does not choose policy API types
-or built-in presets.
-
-Recorded in ADR 0009.
+Recorded in ADRs 0009 and 0054.
 
 ### Reusable Gradle task contract
 
-The class-to-source Gradle task type is a supported API that can be registered independently of the default AnnoDocimal
-Javadoc lifecycle. Issue #35's intended contract is confirmed:
+`SourceProjectionTask` is the supported reusable task type. Its API is limited to the five Gradle property getters for
+classpath-sensitive class directories, include/exclude patterns, nested projection policy, and output directory. It owns
+all-or-nothing synchronized output, deterministic duplicate detection, stale cleanup, cacheability, and configuration-
+cache-safe execution. `CreateClassStubs` is replaced without a shim. IDE model wiring remains consumer-owned.
 
-- arbitrary class inputs and output directory;
-- declared top-level class-file filtering;
-- documentation-sensitive input tracking rather than ABI-only sensitivity;
-- deterministic output with stale-file cleanup;
-- correct up-to-date and build-cache behavior;
-- configuration-cache-safe execution.
-
-The base plugin's `createClassStubs` to `javadoc` setup remains a convenience instance. IDE model wiring remains owned by
-the consumer. Implementation and executable acceptance stay in issue #35 and are not performed in this baseline.
-
-Recorded in ADR 0010.
+Recorded in ADRs 0010 and 0055; issue #35 owns implementation and TestKit acceptance.
 
 ### Layered Gradle plugins
 
-Both published plugin IDs remain supported as an intentional base/opinionated pair:
+The supported plugin IDs form a neutral/opinionated pair:
 
-- `com.blackbuild.annodocimal.base-plugin` owns the conventional `createClassStubs` task and Javadoc connection;
-- `com.blackbuild.annodocimal.plugin` applies the base layer and configures documentation-capture and parameter-metadata
-  compiler prerequisites;
-- independently registered projection tasks require neither convention lifecycle.
+- `com.blackbuild.annodocimal.base-plugin` applies no language plugin, reacts lazily to the Java model, and otherwise
+  leaves manual `SourceProjectionTask` registration available; and
+- `com.blackbuild.annodocimal.groovy-plugin` applies Gradle's Groovy plugin and the base layer, then configures required
+  Groovy/Java compiler metadata.
 
-This preserves issue #28's split and follows Gradle's recommended plugin-composition approach. Both plugin layers must
-configure lazily and remain configuration-cache safe.
+The ambiguous `com.blackbuild.annodocimal.plugin` ID is replaced without a shim. A future Java convention and an external
+shared Groovy/Spock convention remain additive options. Both delivered layers must remain configuration-cache safe.
 
-Recorded in ADR 0011.
+Recorded in ADRs 0011 and 0055.
 
 ### Module-path policy
 
@@ -331,11 +308,11 @@ Each published artifact receives a mechanical compatibility baseline for its exp
 not accidentally freeze every public implementation type, and accepted incompatibilities require release-facing
 rationale.
 
-A dedicated API grilling session is a mandatory 1.0 release-plan step. It must classify every published public type,
-finalize the per-artifact allowlist, and establish the first mechanical baseline. This baseline session schedules that
-gate rather than prematurely performing the final classification.
+Issue #37 completed the public-type classification, finalized every independent allowlist, and specified how the human
+allowlist feeds per-artifact machine-readable source/binary signature snapshots. Issue #51 must resolve the one provisional
+authoring-language slot before implementation locks the first baseline.
 
-Recorded in ADR 0026.
+Recorded in ADR 0026 and `docs/api/1.0-supported-api.md`.
 
 ### Structured protocol release target
 
@@ -474,11 +451,11 @@ Recorded in ADR 0043 and the 1.0 release plan.
 
 ### Explicit projection-policy release gate
 
-An explicit inclusion policy blocks 1.0. The supported projection API must define visibility, nested declarations,
-synthetic and Groovy-generated artifacts, signature closure, and legacy `AnnoDocGenerator` migration. Top-level input
-selection remains in the build/task layer. GitHub issue #39 owns the work.
+The inclusion policy in ADR 0054 defines visibility, nested declarations, synthetic and Groovy runtime artifacts,
+mandatory signature closure, semantic top-level roots, and removal of `AnnoDocGenerator` without a shim. Top-level
+collection selection remains in the build/task layer. GitHub issue #39 owns implementation.
 
-Recorded in ADR 0044 and the 1.0 release plan.
+Recorded in ADRs 0044 and 0054 and the 1.0 release plan.
 
 ### Projection-contract-suite release gate
 
@@ -498,19 +475,19 @@ Recorded in ADR 0046 and the 1.0 release plan.
 
 ### Curated transformation-author API release gate
 
-Delivery of the curated transformation-author facade and documentation value model blocks 1.0. The mandatory API
-grilling designs it, maps known consumers, classifies current helpers, and defines shims or migration without designing
-issue #30's structured carrier schema. This needs a new implementation issue after that grilling and authorized curation.
+Delivery of `AstDocumentation`, immutable `Documentation`, and its builder blocks 1.0. Issue #37 designed the facade,
+mapped consumers, classified current helpers, and selected clean migration without issue #30's carrier schema. Issue #38
+owns implementation; issue #51 and KlumAST #489 must settle its final authoring-language members.
 
-Recorded in ADR 0047 and the 1.0 release plan.
+Recorded in ADRs 0047, 0053, and 0056 and the 1.0 release plan.
 
 ### Narrow source-projection API release gate
 
-Delivery of the narrow implementation-neutral projection service blocks 1.0. It supports source text and managed output
-locations, consumes the explicit policy, and excludes ASM/JavaPoet/parser/visitor implementation types. Whether the
-pre-1.0 `AnnoDocGenerator` API receives shims remains a separate migration decision.
+Delivery of the narrow implementation-neutral projection service blocks 1.0. ADR 0054 defines source text and managed
+file output, policy construction, inclusion and failure behavior, and the supported type allowlist. ASM, JavaPoet,
+parsers, visitors, and shaded types remain internal; `AnnoDocGenerator` receives no shim.
 
-Recorded in ADR 0048 and the 1.0 release plan.
+Recorded in ADRs 0048 and 0054 and the 1.0 release plan.
 
 ### Provisional-API migration rule
 
@@ -527,8 +504,9 @@ issues retain their own acceptance criteria, and the mandatory API grilling is a
 
 Recorded in ADR 0050 and the issue-curation plan.
 
-The tracker and hard-gate issues use a dedicated GitHub `1.0` milestone for queryable progress. Post-1.0 and 2.0 work
-remains outside it. Recorded in ADR 0051.
+The tracker and originally curated hard-gate issues use a dedicated GitHub `1.0` milestone for queryable progress.
+AnnoDocimal #51 is an additional authorized 1.0 prerequisite but its tracker/milestone/label curation remains unchanged
+until separately authorized. Post-1.0 and 2.0 work remains outside the milestone. Recorded in ADRs 0051 and 0056.
 
 The completed historical `initial-release` milestone is closed rather than renamed or reused. Recorded in ADR 0052.
 
@@ -583,9 +561,9 @@ wiring currently belong to the consumer.
 
 ## Architectural pressure points requiring decisions
 
-1. The concrete supported-API allowlist for the annotations, AST-helper, generator, APT, and Gradle integration contract
-   families. This requires a dedicated grilling session before 1.0.
-2. Concrete projection-policy types, presets, and legacy migration.
+1. The authoring/template language in AnnoDocimal #51 and KlumAST #489, including code blocks, possible paragraph kinds,
+   substitution/failure semantics, and the final builder-member allowlist.
+2. The measured minimum supported Gradle version for issue #35's TestKit matrix.
 3. Long-term shared documentation publication and branding mechanics.
 
 Deferred protocol evolution: issue #30 may introduce structured documentation annotations and targets a future 2.0
@@ -601,5 +579,7 @@ decision and coordinated migration, not a repository-local build simplification.
 ## Applied issue map
 
 The authorized curation pass created tracker #47 and gate issues #37–#41 and #43–#46. Existing 1.0 gates #9, #19,
-#32, #33, #35, and #36 were curated into milestone `1.0`; #18, #22, and #25 were closed with confirmed rationale.
-Detailed scope, dependency order, and non-gates live in `docs/implementation/1.0-issue-curation-plan.md`.
+#32, #33, #35, and #36 were curated into milestone `1.0`; #36 was later completed through merged PR #50. Issues #18,
+#22, and #25 were closed with confirmed rationale. The issue #37 session separately created unlabelled AnnoDocimal #51
+and KlumAST #489 without changing the tracker or other existing issues. Detailed scope, dependency order, and non-gates
+live in `docs/implementation/1.0-issue-curation-plan.md`.

--- a/docs/migration/0.x-to-1.0-authoring-language.md
+++ b/docs/migration/0.x-to-1.0-authoring-language.md
@@ -16,8 +16,13 @@ Use `summary`, `paragraph`, and `codeBlock` to author ordered content. Use `appe
 `filterParameters` when composing a captured document for a generated member. Rendered parameter tags follow the final
 method signature automatically during `AstDocumentation.attach`.
 
+Absence is explicit in the 1.0 Java API. `getSummary()`, `getReturnDescription()`, and `Link.getLabel()` return
+`Optional<String>`. Public arguments reject `null`; clear singular content with `clearSummary()` or `clearReturn()`,
+replace categories with empty collections, and remove attached documentation with `Documentation.empty()`. Use
+`paragraph` and `returns`; the redundant `appendParagraph` and `replaceReturn` aliases are not supported 1.0 methods.
+
 Replace implicit template defaults and value-presence conditionals with required `{{key}}` placeholders. Supply values
-explicitly as `String`s. `{{param:key?fragment}}` is the only conditional form; it omits the fragment only when the
+explicitly as `String`s through `Map<String, String>`. `{{param:key?fragment}}` is the only conditional form; it omits the fragment only when the
 generated target lacks that parameter. Do not rely on `@template` tags to supply values.
 
 KlumAST's 4.0 migration is owned by KlumAST #461. Its authoring portion maps to this document; it does not retain any

--- a/docs/migration/0.x-to-1.0-supported-api.md
+++ b/docs/migration/0.x-to-1.0-supported-api.md
@@ -1,0 +1,82 @@
+# Supported-API migration from 0.x to 1.0
+
+AnnoDocimal 1.0 deliberately replaces accidental public helper surfaces instead of carrying compatibility shims. The
+persisted `@AnnoDoc(String)` and documentation-properties protocols remain readable; the clean cut applies to source APIs
+and the ambiguous opinionated plugin ID.
+
+## Transformation-author migration
+
+| 0.x usage | 1.0 replacement |
+|---|---|
+| `ASTExtractor.extractDocumentation` or `extractDocText` | `AstDocumentation.extractExact` and immutable `Documentation` |
+| `AnnoDocUtil.addDocumentation(node, text)` | `AstDocumentation.attachText(node, text)` |
+| `AnnoDocUtil.addDocumentation(node, builder)` | `AstDocumentation.attach(node, builder.build())` |
+| `DocText` parsing, inspection, or tag replacement | `Documentation.parse`, value accessors, and `toBuilder()` |
+| `DocBuilder` / `JavadocDocBuilder` | `Documentation.Builder` and `Documentation.render()` |
+| `JavaDocUtil.toLinkString` | `AstDocumentation.referenceTo` |
+| Direct metadata constants, source extractors, visitors, or Groovy-version handlers | No replacement; consume the facade's supported behavior |
+
+`extractExact` never performs inherited lookup. Do not replace an old fallback overload with implicit hierarchy traversal;
+issue #10 will add separately named resolved extraction after 1.0.
+
+The final template-operation migration, including code blocks and possible paragraph kinds, is intentionally pending
+AnnoDocimal #51 and KlumAST #489. Current `TemplateHandler` and specialized builder vocabulary are not compatibility
+bridges while that work is open.
+
+## Source-projection migration
+
+Replace:
+
+```java
+AnnoDocGenerator.generate(classFile, outputDirectory);
+```
+
+with an explicitly policy-configured projector:
+
+```java
+SourceProjector projector = new SourceProjector(ProjectionPolicy.documentation());
+Path sourceFile = projector.projectToDirectory(classFile, outputDirectory);
+```
+
+Use `projectToText` when the caller owns persistence. Collection scanning, top-level selection, and stale-output cleanup
+belong to the caller or `SourceProjectionTask`; they are not implicit singleton behavior of `SourceProjector`.
+
+## Gradle migration
+
+Replace custom or 0.x task types with `SourceProjectionTask` and configure its Gradle properties directly. For KlumAST's
+IDE-only DSL mirrors, the intended configuration selects `**/*_DSL.class`, writes to its separate source-mirror
+directory, and leaves IDEA model wiring in KlumAST. The conventional task remains named `createClassStubs`.
+
+Replace the opinionated plugin ID:
+
+```groovy
+plugins {
+    id 'com.blackbuild.annodocimal.groovy-plugin' version '<version>'
+}
+```
+
+The Groovy plugin applies Gradle's `groovy` plugin and the neutral base plugin. Consumers that already own their language
+model, use cross-project class outputs, or want only manual tasks may instead apply
+`com.blackbuild.annodocimal.base-plugin` or register `SourceProjectionTask` directly. Plugin implementation classes are
+not supported application targets.
+
+## KlumAST consumer map
+
+KlumAST issue #461 owns the 4.0 migration. Its current direct calls map as follows:
+
+- `ASTExtractor` to `AstDocumentation.extractExact` and `Documentation`;
+- `AnnoDocUtil` string and builder attachment to `attachText` and `attach`;
+- `DocText`, `DocBuilder`, and `JavadocDocBuilder` to `Documentation` and its builder;
+- `JavaDocUtil` to `referenceTo`;
+- `AnnoDocGenerator` and the duplicated `CreateKlumDslSourceMirrors` action to `SourceProjector` or
+  `SourceProjectionTask` with `**/*_DSL.class`;
+- application by `AnnoDocimalPlugin.class` to the supported Groovy plugin ID; and
+- `AnnoDoc` and `InlineJavadocs` remain protocol annotations.
+
+The authoring-language portion of that migration is completed jointly through KlumAST #489 and AnnoDocimal #51.
+KlumAST #455 remains the separate owner of the cross-project multi-Groovy build decision.
+
+## Module-path migration
+
+The stable automatic module names delivered by issue #36 are unchanged by this API migration. Named consumers should also
+apply [the 0.x-to-1.0 module-path migration](0.x-to-1.0-module-path.md).

--- a/docs/migration/0.x-to-1.0-supported-api.md
+++ b/docs/migration/0.x-to-1.0-supported-api.md
@@ -19,9 +19,15 @@ and the ambiguous opinionated plugin ID.
 `extractExact` never performs inherited lookup. Do not replace an old fallback overload with implicit hierarchy traversal;
 issue #10 will add separately named resolved extraction after 1.0.
 
-The final template-operation migration, including code blocks and possible paragraph kinds, is intentionally pending
-AnnoDocimal #51 and KlumAST #489. Current `TemplateHandler` and specialized builder vocabulary are not compatibility
-bridges while that work is open.
+The final authoring-language migration is documented in
+[the focused authoring guide](0.x-to-1.0-authoring-language.md). It uses first-class prose/code blocks and explicit named
+templates; generic block kinds and paragraph qualifiers remain additive options after 1.0. Current `TemplateHandler` and
+specialized builder vocabulary are not compatibility bridges.
+
+Scalar absence is explicit: `getSummary()`, `getReturnDescription()`, and `Link.getLabel()` return `Optional<String>`.
+Builder and facade arguments reject `null`; use `clearSummary()`, `clearReturn()`, empty replacement collections, or
+`Documentation.empty()` for deliberate removal. `paragraph` and `returns` replace the redundant 0.x-style aliases
+`appendParagraph` and `replaceReturn` before the 1.0 baseline is locked. Template maps are `Map<String, String>`.
 
 ## Source-projection migration
 
@@ -73,8 +79,9 @@ KlumAST issue #461 owns the 4.0 migration. Its current direct calls map as follo
 - application by `AnnoDocimalPlugin.class` to the supported Groovy plugin ID; and
 - `AnnoDoc` and `InlineJavadocs` remain protocol annotations.
 
-The authoring-language portion of that migration is completed jointly through KlumAST #489 and AnnoDocimal #51.
-KlumAST #455 remains the separate owner of the cross-project multi-Groovy build decision.
+The authoring-language contract and consumer requirements were completed jointly through KlumAST #489 and AnnoDocimal
+#51. KlumAST issue #461 owns applying the complete 0.x-to-1.0 consumer migration. KlumAST #455 remains the separate
+owner of the cross-project multi-Groovy build decision.
 
 ## Module-path migration
 


### PR DESCRIPTION
## Summary

- record the explicit supported-API classification for all 120 public types across the six published artifacts
- finalize the annotation/protocol, transformation-author, source-projection, and Gradle contract allowlists
- reconcile the completed documentation-authoring work from AnnoDocimal #51 and KlumAST #489, including the remaining pre-baseline Java API corrections for #38
- document the clean 0.x-to-1.0 migration and the rules for generating mechanical source/binary compatibility baselines
- update the release, issue-curation, and architecture records so #38 and #39 are decision-ready

## Why

AnnoDocimal 0.x exposes implementation machinery through public bytecode. The 1.0 contract needs an intentional compatibility boundary based on supported capabilities, not visibility, shading, service-provider names, or current implementation technology. This PR records the complete API-1 decision set for issue #37 without implementing the production APIs owned by #38 or #39.

## User and developer impact

There are no production-code changes in this PR. The records define the supported 1.0 surface, preserve the existing persisted documentation protocols, give current consumers—especially KlumAST—a clean migration path, and make future compatibility checks mechanically enforceable without freezing accidental APIs.

## Validation

- `./gradlew check`
- verified the built-artifact public-type counts as `2 / 2 / 24 / 1 / 88 / 3` (120 total)
- verified every public type is present in the classification record
- `git diff --check origin/master...HEAD`

## Scope notes

- does not implement #38 or #39
- does not reopen issue #30's structured carrier schema, issue #10's inherited-resolution API, or KlumAST #455
- preserves the merged JPMS decisions from #36

Related to #37.
