### PR TITLE
Isolate Groovy compatibility test lanes

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -5,3 +5,12 @@ plugins {
 repositories {
     gradlePluginPortal() // so that external plugins can be resolved in dependencies section
 }
+
+dependencies {
+    implementation 'gradle.plugin.com.hierynomus.gradle.plugins:license-gradle-plugin:0.16.1'
+    testImplementation 'org.spockframework:spock-core:2.4-groovy-3.0'
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+}

--- a/buildSrc/src/main/groovy/annodocimal-multigroovy.conventions.gradle
+++ b/buildSrc/src/main/groovy/annodocimal-multigroovy.conventions.gradle
@@ -1,3 +1,5 @@
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier
+
 plugins {
     id "annodocimal-base.conventions"
     id 'jvm-test-suite'
@@ -31,6 +33,12 @@ testing {
                     srcDirs = ['src/test/groovy']
                     destinationDirectory = file("build/classes/groovy/test-g$groovyVersion")
                 }
+                java {
+                    srcDirs = ['src/test/java']
+                }
+                resources {
+                    srcDirs = ['src/test/resources']
+                }
             }
 
             dependencies {
@@ -38,7 +46,6 @@ testing {
                 implementation libs.jb.anno
                 implementation libs.spock.junit4."g$groovyVersion"
                 implementation libs.groovy."v$groovyVersion"
-                implementation sourceSets.test.output
             }
         }
         groovy4Tests(JvmTestSuite)
@@ -46,7 +53,98 @@ testing {
     }
 }
 
+def testLanes = [
+        3: [
+                sourceSet : sourceSets.test,
+                classpath : configurations.testRuntimeClasspath,
+                compileTask: tasks.named('compileTestGroovy'),
+                testTask   : tasks.named('test')
+        ],
+        4: [
+                sourceSet : sourceSets.groovy4Tests,
+                classpath : configurations.groovy4TestsRuntimeClasspath,
+                compileTask: tasks.named('compileGroovy4TestsGroovy'),
+                testTask   : tasks.named('groovy4Tests')
+        ],
+        5: [
+                sourceSet : sourceSets.groovy5Tests,
+                classpath : configurations.groovy5TestsRuntimeClasspath,
+                compileTask: tasks.named('compileGroovy5TestsGroovy'),
+                testTask   : tasks.named('groovy5Tests')
+        ]
+]
+
+def verifyLaneConfiguration = { generation, lane ->
+    def components = lane.classpath.incoming.resolutionResult.allComponents*.id.findAll {
+        it instanceof ModuleComponentIdentifier
+    }
+    def expectedGroovyGroup = generation == 3 ? 'org.codehaus.groovy' : 'org.apache.groovy'
+    def groovyComponents = components.findAll { it.group in ['org.codehaus.groovy', 'org.apache.groovy'] }
+    if (groovyComponents.isEmpty() || groovyComponents.any {
+        it.group != expectedGroovyGroup || it.version != libs.versions.groovy."v$generation".get()
+    })
+        throw new GradleException("Groovy $generation lane contains mismatched Groovy modules: $groovyComponents")
+
+    def spockComponents = components.findAll { it.group == 'org.spockframework' }
+    if (spockComponents.isEmpty() || spockComponents.any {
+        it.version != libs.versions.spock."g$generation".get()
+    })
+        throw new GradleException("Groovy $generation lane contains mismatched Spock modules: $spockComponents")
+
+    def forbiddenOutput = testLanes.findAll { otherGeneration, ignored -> otherGeneration != generation }
+            .values()
+            .collectMany { otherLane ->
+                otherLane.sourceSet.output.classesDirs.files + [otherLane.sourceSet.output.resourcesDir]
+            }
+            .findAll { it != null }
+    def sourceSetCompileLeak = lane.sourceSet.compileClasspath.files.intersect(forbiddenOutput)
+    if (!sourceSetCompileLeak.isEmpty())
+        throw new GradleException("Groovy $generation source-set compile classpath contains another lane's output: $sourceSetCompileLeak")
+
+    def groovyCompileLeak = lane.compileTask.get().classpath.files.intersect(forbiddenOutput)
+    if (!groovyCompileLeak.isEmpty())
+        throw new GradleException("Groovy $generation Groovy compile classpath contains another lane's output: $groovyCompileLeak")
+
+    def testTask = lane.testTask.get()
+    def runtimeLeak = testTask.classpath.files.intersect(forbiddenOutput)
+    if (!runtimeLeak.isEmpty())
+        throw new GradleException("Groovy $generation test runtime classpath contains another lane's output: $runtimeLeak")
+
+    def expectedClasses = lane.sourceSet.output.classesDirs.files
+    if (testTask.testClassesDirs.files != expectedClasses)
+        throw new GradleException("Groovy $generation executes unexpected test classes: ${testTask.testClassesDirs.files}")
+
+    def expectedResults = layout.buildDirectory.dir("test-results/${testTask.name}").get().asFile
+    if (testTask.reports.junitXml.outputLocation.get().asFile != expectedResults)
+        throw new GradleException("Groovy $generation writes JUnit results outside $expectedResults")
+}
+
+testLanes.each { generation, lane ->
+    lane.testTask.configure {
+        doFirst {
+            verifyLaneConfiguration(generation, lane)
+        }
+    }
+}
+
+tasks.register('verifyTestLaneIsolation') {
+    group = 'verification'
+    description = 'Verifies matching Groovy/Spock dependencies, isolated test output, and lane-specific JUnit results.'
+    dependsOn testLanes.values()*.testTask
+
+    doLast {
+        testLanes.each { generation, lane ->
+            verifyLaneConfiguration(generation, lane)
+            def testTask = lane.testTask.get()
+            def expectedResults = layout.buildDirectory.dir("test-results/${testTask.name}").get().asFile
+            if (fileTree(expectedResults).matching { include 'TEST-*.xml' }.isEmpty())
+                throw new GradleException("Groovy $generation did not produce JUnit results in $expectedResults")
+        }
+    }
+}
+
 tasks.named('check') {
     dependsOn(testing.suites.groovy4Tests)
     dependsOn(testing.suites.groovy5Tests)
+    dependsOn(tasks.named('verifyTestLaneIsolation'))
 }

--- a/buildSrc/src/test/groovy/AnnodocimalMultigroovyConventionTest.groovy
+++ b/buildSrc/src/test/groovy/AnnodocimalMultigroovyConventionTest.groovy
@@ -1,0 +1,171 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2024 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import spock.lang.Specification
+import spock.lang.TempDir
+
+class AnnodocimalMultigroovyConventionTest extends Specification {
+
+    @TempDir
+    File projectDir
+
+    def "compiles shared test inputs and records results in every Groovy lane"() {
+        given:
+        prepareProject()
+
+        when:
+        BuildResult result = run('verifyTestLaneIsolation').build()
+
+        then:
+        result.task(':verifyTestLaneIsolation').outcome.name() == 'SUCCESS'
+        laneOutput('test', 'test', 'test').every { it.exists() }
+        laneOutput('test-g4', 'groovy4Tests', 'groovy4Tests').every { it.exists() }
+        laneOutput('test-g5', 'groovy5Tests', 'groovy5Tests').every { it.exists() }
+    }
+
+    def "rejects Groovy 3 compiled test output in a compatibility lane"() {
+        given:
+        prepareProject()
+        file('build.gradle') << '''
+
+dependencies {
+    groovy4TestsImplementation sourceSets.test.output
+}
+'''
+
+        when:
+        BuildResult result = run('groovy4Tests').buildAndFail()
+
+        then:
+        result.output.contains('Groovy 4 source-set compile classpath contains another lane\'s output:')
+        result.output.contains('build/classes/groovy/test')
+        result.output.contains('build/classes/java/test')
+        result.output.contains('build/resources/test')
+    }
+
+    private List<File> laneOutput(String groovyDirectory, String suiteName, String resultName) {
+        return [
+                file("build/classes/groovy/$groovyDirectory/example/LaneSpec.class"),
+                file("build/classes/java/$suiteName/example/SharedHelper.class"),
+                file("build/resources/$suiteName/shared.txt"),
+                file("build/test-results/$resultName/TEST-example.LaneSpec.xml")
+        ]
+    }
+
+    private void prepareProject() {
+        file('settings.gradle').text = '''
+pluginManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+gradle.beforeProject {
+    it.ext.groovyVersion = 'v3'
+}
+
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+    }
+    versionCatalogs {
+        libs {
+            version('groovy-v3', '3.0.25')
+            version('groovy-v4', '4.0.32')
+            version('groovy-v5', '5.0.6')
+            library('groovy-v3', 'org.codehaus.groovy', 'groovy-all').versionRef('groovy-v3')
+            library('groovy-v4', 'org.apache.groovy', 'groovy-all').versionRef('groovy-v4')
+            library('groovy-v5', 'org.apache.groovy', 'groovy-all').versionRef('groovy-v5')
+
+            library('jb-anno', 'org.jetbrains', 'annotations').version('16.0.2')
+
+            version('spock-g3', '2.4-groovy-3.0')
+            version('spock-g4', '2.4-groovy-4.0')
+            version('spock-g5', '2.4-groovy-5.0')
+            library('spock-g3', 'org.spockframework', 'spock-core').versionRef('spock-g3')
+            library('spock-junit4-g3', 'org.spockframework', 'spock-junit4').versionRef('spock-g3')
+            library('spock-g4', 'org.spockframework', 'spock-core').versionRef('spock-g4')
+            library('spock-junit4-g4', 'org.spockframework', 'spock-junit4').versionRef('spock-g4')
+            library('spock-g5', 'org.spockframework', 'spock-core').versionRef('spock-g5')
+            library('spock-junit4-g5', 'org.spockframework', 'spock-junit4').versionRef('spock-g5')
+            bundle('spock-groovy-v3', ['spock-g3', 'spock-junit4-g3', 'groovy-v3'])
+
+            library('bytebuddy', 'net.bytebuddy', 'byte-buddy').version('1.9.3')
+            library('objenesis', 'org.objenesis', 'objenesis').version('2.6')
+            library('jpl', 'org.junit.platform', 'junit-platform-launcher').version('1.9.2')
+            bundle('spockRuntime', ['bytebuddy', 'objenesis'])
+        }
+    }
+}
+
+rootProject.name = 'test-project'
+'''
+        file('build.gradle').text = '''
+plugins {
+    id 'annodocimal-multigroovy.conventions'
+}
+'''
+        file('src/test/groovy/example/LaneSpec.groovy').text = '''
+package example
+
+import spock.lang.Specification
+
+class LaneSpec extends Specification {
+
+    def "uses shared Java and resource inputs"() {
+        expect:
+        SharedHelper.value() == 'shared'
+        getClass().getResource('/shared.txt').text.trim() == 'shared'
+    }
+}
+'''
+        file('src/test/java/example/SharedHelper.java').text = '''
+package example;
+
+public class SharedHelper {
+
+    public static String value() {
+        return "shared";
+    }
+}
+'''
+        file('src/test/resources/shared.txt').text = 'shared\n'
+    }
+
+    private GradleRunner run(String... arguments) {
+        return GradleRunner.create()
+                .withProjectDir(projectDir)
+                .withArguments(arguments + ['--stacktrace'])
+                .withPluginClasspath()
+    }
+
+    private File file(String path) {
+        File target = new File(projectDir, path)
+        target.parentFile.mkdirs()
+        return target
+    }
+}

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -20,6 +20,13 @@ Start with the narrowest relevant test. Run Groovy 4 and 5 during development wh
 behavior, Groovy syntax, bytecode shape, dependency compatibility, or known output differences. Run root `./gradlew check`
 before final handoff.
 
+Projects using the multi-Groovy convention share `src/test/groovy`, `src/test/java`, and `src/test/resources` as source
+inputs, then compile and process those inputs into separate output directories for every lane. Groovy 4 and 5 therefore
+reuse neither Groovy 3 test classes nor Groovy 3 test resources; only the production artifact and explicitly declared
+test-fixture dependencies are shared. `verifyTestLaneIsolation`, which is part of each affected project's `check`, rejects
+mismatched Groovy or Spock dependencies, cross-lane compiled output on compile or runtime classpaths, unexpected test
+class directories, and missing or misplaced lane-specific JUnit results.
+
 Gradle-plugin changes require TestKit evidence proportionate to the contract, including task input sensitivity,
 up-to-date behavior, build-cache restoration, stale-output handling, and configuration-cache reuse where claimed.
 Source-projection changes require exact generated-source assertions for affected Java and Groovy shapes.

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -22,10 +22,12 @@ before final handoff.
 
 Projects using the multi-Groovy convention share `src/test/groovy`, `src/test/java`, and `src/test/resources` as source
 inputs, then compile and process those inputs into separate output directories for every lane. Groovy 4 and 5 therefore
-reuse neither Groovy 3 test classes nor Groovy 3 test resources; only the production artifact and explicitly declared
-test-fixture dependencies are shared. `verifyTestLaneIsolation`, which is part of each affected project's `check`, rejects
+reuse neither Groovy 3 test classes nor Groovy 3 test resources. Across compiled and runtime inputs, sharing is limited to
+the production artifact and explicitly declared shared test dependencies. `verifyTestLaneIsolation`, which is part of
+each affected project's `check`, rejects
 mismatched Groovy or Spock dependencies, cross-lane compiled output on compile or runtime classpaths, unexpected test
-class directories, and missing or misplaced lane-specific JUnit results.
+class directories, and missing or misplaced lane-specific JUnit results. Build-logic TestKit coverage proves both the
+isolated success path and rejection when a compatibility lane receives Groovy 3 compiled test output.
 
 Gradle-plugin changes require TestKit evidence proportionate to the contract, including task input sensitivity,
 up-to-date behavior, build-cache restoration, stale-output handling, and configuration-cache reuse where claimed.


### PR DESCRIPTION
Closes #56

## What changed

- Compile shared Groovy, Java, and resource test inputs into generation-specific Groovy 3, 4, and 5 outputs.
- Remove the Groovy 3 `sourceSets.test.output` dependency from the Groovy 4/5 suites.
- Add `verifyTestLaneIsolation` to reject mismatched Groovy/Spock dependencies, cross-lane compile or runtime output, unexpected test class directories, and missing or misplaced JUnit XML.
- Add standalone TestKit coverage for both isolated execution and the regression case that restores the old Groovy 3 output edge.
- Document the durable test-lane evidence boundary.

## Why

The compatibility suites had separate Groovy compilation destinations but also consumed the complete Groovy 3 test output. That made a green Groovy 4/5 run ambiguous because Groovy 3-compiled test classes and resources could be observed or shadow generation-specific output.

## Impact

Groovy 4 and 5 now compile and execute their own test classes while reusing shared source inputs and explicitly declared test dependencies. Production remains one Groovy 3-built artifact set; published coordinates, publication topology, public behavior, and CI topology are unchanged.

## Validation

- `./gradlew :buildSrc:test`
- `./gradlew clean check` — 92 tasks
- Focused mutation evidence: restoring `groovy4TestsImplementation sourceSets.test.output` fails before test execution and identifies the Groovy 3 Java, Groovy, and resource output directories.
- Two-axis repository review repeated after the follow-up commit: no hard standards findings and no spec findings.
