### PR TITLE
Document test issue traceability and documentation-only validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,8 @@ names unless a conflict or generated-source constraint requires qualification. S
 
 Groovy 3 is the baseline `test` lane. Groovy 4 and Groovy 5 compatibility use `groovy4Tests` and `groovy5Tests`; root
 `check` includes the compatibility suites for projects using the multi-Groovy convention. See `docs/agents/testing.md`.
+Documentation-only changes that cannot affect compilation, test execution, generated output, or runtime behavior do not
+require Gradle checks; run the applicable documentation and diff checks instead.
 Every newly added test must carry its driving GitHub issue number in Spock's `@Issue`; a class-level annotation is
 sufficient while one issue owns the class, and individual methods identify tests driven by later or different issues.
 Add or amend `@Issue` on changed existing tests only for significant behavioral changes. Apply this rule prospectively;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,10 @@ names unless a conflict or generated-source constraint requires qualification. S
 
 Groovy 3 is the baseline `test` lane. Groovy 4 and Groovy 5 compatibility use `groovy4Tests` and `groovy5Tests`; root
 `check` includes the compatibility suites for projects using the multi-Groovy convention. See `docs/agents/testing.md`.
+Every newly added test must carry its driving GitHub issue number in Spock's `@Issue`; a class-level annotation is
+sufficient while one issue owns the class, and individual methods identify tests driven by later or different issues.
+Add or amend `@Issue` on changed existing tests only for significant behavioral changes. Apply this rule prospectively;
+do not retrofit unrelated tests.
 
 ### Issue implementation and commits
 

--- a/docs/agents/pull-requests.md
+++ b/docs/agents/pull-requests.md
@@ -15,6 +15,8 @@ or documentation semantics.
 - Inspect all required CI and SonarCloud findings for the current revision. A green job proves the tested state, not that
   an architectural decision has been made.
 - Run focused tests first, then all affected Groovy lanes; use root `check` for final repository verification.
+- Documentation-only changes that cannot affect compilation, test execution, generated output, or runtime behavior may
+  omit Gradle checks when the applicable documentation and diff checks are reported instead.
 - Verify that every newly added test carries its driving GitHub issue number in Spock's `@Issue`. A class-level annotation
   is sufficient while one issue owns the class; use method-level annotations for tests driven by later or different
   issues. Add or amend `@Issue` on changed existing tests only for significant behavioral changes, and do not retrofit

--- a/docs/agents/pull-requests.md
+++ b/docs/agents/pull-requests.md
@@ -15,6 +15,10 @@ or documentation semantics.
 - Inspect all required CI and SonarCloud findings for the current revision. A green job proves the tested state, not that
   an architectural decision has been made.
 - Run focused tests first, then all affected Groovy lanes; use root `check` for final repository verification.
+- Verify that every newly added test carries its driving GitHub issue number in Spock's `@Issue`. A class-level annotation
+  is sufficient while one issue owns the class; use method-level annotations for tests driven by later or different
+  issues. Add or amend `@Issue` on changed existing tests only for significant behavioral changes, and do not retrofit
+  unrelated tests.
 
 ## Review feedback
 

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -20,6 +20,12 @@ Start with the narrowest relevant test. Run Groovy 4 and 5 during development wh
 behavior, Groovy syntax, bytecode shape, dependency compatibility, or known output differences. Run root `./gradlew check`
 before final handoff.
 
+A documentation-only change does not require the Gradle test lanes or root `check` when its changes cannot affect
+compilation, test execution, generated output, or runtime behavior. Run `git diff --check` plus any applicable Markdown,
+link, rendering, or documentation-generation checks instead, and report the omitted Gradle validation. Treat changes to
+build configuration, executable or compiled examples, generated-source inputs, and test fixtures as code changes rather
+than documentation-only changes.
+
 Projects using the multi-Groovy convention share `src/test/groovy`, `src/test/java`, and `src/test/resources` as source
 inputs, then compile and process those inputs into separate output directories for every lane. Groovy 4 and 5 therefore
 reuse neither Groovy 3 test classes nor Groovy 3 test resources. Across compiled and runtime inputs, sharing is limited to

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -36,6 +36,19 @@ Source-projection changes require exact generated-source assertions for affected
 The Gradle integration must document and verify a supported Gradle range. Use the wrapper as the primary development
 baseline and test the documented minimum separately. Raising that minimum is a breaking compatibility change.
 
+## Issue traceability
+
+Every newly added test must carry Spock's `@Issue` annotation with the number of its driving GitHub issue. When one issue
+owns a complete specification or test class, put `@Issue` on the class; that annotation is sufficient for every test in
+the class driven by that issue. Put `@Issue` on an individual test when a later or different issue drives that test.
+
+When a change affects an existing test, add or amend its `@Issue` annotation only if the test change is significant. A
+change is significant when it materially changes the tested behavior, scenario, or expected contract. Mechanical edits,
+renames, formatting, and adjustments to shared setup do not require issue-annotation churn.
+
+This policy applies prospectively. Do not expand the current work by retrofitting unrelated parts of the existing test
+suite.
+
 Every ignored, conditionally ignored, or pending test must state an actionable reason and, where possible, the condition
 for removing the suppression.
 


### PR DESCRIPTION
## Summary

- require newly added Spock tests to carry their driving GitHub issue through `@Issue`
- define class-level ownership, method-level later/different issue attribution, and significant-change handling for existing tests
- keep the policy prospective so unrelated test suites are not retrofitted
- allow documentation-only changes to use applicable documentation and diff checks instead of Gradle when they cannot affect compilation, test execution, generated output, or runtime behavior

## Impact

This adds repository-owned contributor and pull-request guidance only. It does not change production code, test sources,
generated output, or runtime behavior, and it does not import KlumAST-specific DSL or documentary-test policy.

## Validation

- `git diff --check 47f08b5d00a57d245f7486846a1b5af6397b7401...HEAD`
- `./gradlew check` passed after the traceability-policy commit
- Gradle was intentionally not rerun for the documentation-only validation-policy follow-up; no Markdown, link, rendering, or documentation-generation checker is configured
- two-axis repository review found no hard standards violations and no specification findings
