### PR TITLE
Generate valid source for inherited generic API shapes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,9 @@
   removed; see the [source-projection guide](docs/source-projection.md) and
   [0.x-to-1.0 migration](docs/migration/0.x-to-1.0-supported-api.md).
 
+- Corrected inherited generic source projection so nested types retain their parameterized enclosing owner, including
+  bounds and wildcards, and the resulting Java compiles without unresolved generic context.
+
 - Stabilized the 1.0 transformation-authoring language around `Documentation` and `AstDocumentation`, including
   first-class code blocks, deterministic normalization, one-pass named templates, canonical links, and exact
   extraction/attachment. The final Java shape uses optional scalar accessors, explicit clearing, strict null handling,

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,8 +18,9 @@
   removed; see the [source-projection guide](docs/source-projection.md) and
   [0.x-to-1.0 migration](docs/migration/0.x-to-1.0-supported-api.md).
 
-- Corrected inherited generic source projection so nested types retain their parameterized enclosing owner, including
-  bounds and wildcards, and the resulting Java compiles without unresolved generic context.
+- Corrected inherited generic source projection so inherited type variables are resolved through parameterized API
+  relationships and nested types retain their enclosing owner, including bounds and wildcards. The resulting Java now
+  compiles without unresolved generic context.
 
 - Stabilized the 1.0 transformation-authoring language around `Documentation` and `AstDocumentation`, including
   first-class code blocks, deterministic normalization, one-pass named templates, canonical links, and exact

--- a/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/FormalParameterParser.java
+++ b/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/FormalParameterParser.java
@@ -47,7 +47,7 @@ abstract class FormalParameterParser extends SignatureVisitor {
     }
 
     protected FormalParameterParser(Function<String, ClassName> classNameResolver) {
-        this(classNameResolver, name -> TypeVariableName.get(name));
+        this(classNameResolver, TypeVariableName::get);
     }
 
     protected FormalParameterParser(Function<String, ClassName> classNameResolver,

--- a/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/FormalParameterParser.java
+++ b/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/FormalParameterParser.java
@@ -25,6 +25,7 @@ package com.blackbuild.annodocimal.generator;
 
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.TypeName;
+import com.squareup.javapoet.TypeVariableName;
 import org.codehaus.groovy.control.CompilerConfiguration;
 import org.objectweb.asm.signature.SignatureVisitor;
 
@@ -39,14 +40,21 @@ abstract class FormalParameterParser extends SignatureVisitor {
     private List<TypeName> parameterBounds = new ArrayList<>();
     private final Map<String, List<TypeName>> typeParameters = new LinkedHashMap<>();
     private final Function<String, ClassName> classNameResolver;
+    private final Function<String, TypeName> typeVariableResolver;
 
     protected FormalParameterParser() {
         this(TypeConversion::fromInternalNameToClassName);
     }
 
     protected FormalParameterParser(Function<String, ClassName> classNameResolver) {
+        this(classNameResolver, name -> TypeVariableName.get(name));
+    }
+
+    protected FormalParameterParser(Function<String, ClassName> classNameResolver,
+                                    Function<String, TypeName> typeVariableResolver) {
         super(CompilerConfiguration.ASM_API_VERSION);
         this.classNameResolver = Objects.requireNonNull(classNameResolver, "classNameResolver");
+        this.typeVariableResolver = Objects.requireNonNull(typeVariableResolver, "typeVariableResolver");
     }
 
     @Override
@@ -57,7 +65,7 @@ abstract class FormalParameterParser extends SignatureVisitor {
 
     @Override
     public SignatureVisitor visitClassBound() {
-        return new TypeSignatureParser(classNameResolver) {
+        return new TypeSignatureParser(classNameResolver, typeVariableResolver) {
             @Override
             void finished(TypeName result) {
                 parameterBounds.add(result);

--- a/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/JavaPoetClassVisitor.java
+++ b/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/JavaPoetClassVisitor.java
@@ -32,6 +32,7 @@ import org.objectweb.asm.signature.SignatureVisitor;
 import javax.lang.model.element.Modifier;
 import java.io.IOException;
 import java.util.*;
+import java.util.function.Function;
 import java.util.regex.Pattern;
 
 import static java.util.stream.Collectors.toSet;
@@ -46,6 +47,7 @@ class JavaPoetClassVisitor extends ClassVisitor {
     private final Set<String> groovyRuntimeFields;
     private TypeSpec.Builder typeBuilder;
     private TypeSpec type;
+    private String internalName;
     private String packageName;
     private ClassName className;
     private TypeSpec.Kind kind;
@@ -63,6 +65,7 @@ class JavaPoetClassVisitor extends ClassVisitor {
 
     @Override
     public void visit(int version, int access, String name, String signature, String superName, String[] interfaceNames) {
+        internalName = name;
         prepareTypeBuilder(access, name);
         if (signature != null) {
             ClassSignatureParser.parseClassSignature(signature, typeBuilder, kind,
@@ -190,10 +193,14 @@ class JavaPoetClassVisitor extends ClassVisitor {
         Map<Integer, List<AnnotationSpec>> parameterAnnotations = new HashMap<>();
 
         if (signature != null) {
-            FormalParameterParser v = new FormalParameterParser(specConverter::toClassName) {
+            Map<String, TypeName> inheritedVariables = specConverter.inheritedTypeVariables(
+                    internalName, name, desc, signature);
+            Function<String, TypeName> variableResolver = variable -> inheritedVariables.getOrDefault(
+                    variable, TypeVariableName.get(variable));
+            FormalParameterParser v = new FormalParameterParser(specConverter::toClassName, variableResolver) {
                 @Override
                 public SignatureVisitor visitParameterType() {
-                    return new TypeSignatureParser(specConverter::toClassName) {
+                    return new TypeSignatureParser(specConverter::toClassName, variableResolver) {
                         @Override
                         void finished(TypeName result) {
                             parameterTypes.add(result);
@@ -203,7 +210,7 @@ class JavaPoetClassVisitor extends ClassVisitor {
 
                 @Override
                 public SignatureVisitor visitReturnType() {
-                    return new TypeSignatureParser(specConverter::toClassName) {
+                    return new TypeSignatureParser(specConverter::toClassName, variableResolver) {
                         @Override
                         void finished(TypeName result) {
                             methodBuilder.returns(result);
@@ -213,7 +220,7 @@ class JavaPoetClassVisitor extends ClassVisitor {
 
                 @Override
                 public SignatureVisitor visitExceptionType() {
-                    return new TypeSignatureParser(specConverter::toClassName) {
+                    return new TypeSignatureParser(specConverter::toClassName, variableResolver) {
                         @Override
                         void finished(TypeName result) {
                             methodBuilder.addException(result);

--- a/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/SpecConverter.java
+++ b/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/SpecConverter.java
@@ -26,7 +26,9 @@ package com.blackbuild.annodocimal.generator;
 import com.squareup.javapoet.ArrayTypeName;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.JavaFile;
+import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
+import com.squareup.javapoet.TypeVariableName;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
@@ -43,6 +45,7 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Deque;
@@ -52,6 +55,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 /**
@@ -223,6 +227,145 @@ final class SpecConverter {
             case Type.ARRAY -> ArrayTypeName.of(toTypeName(type.getElementType()));
             default -> TypeConversion.toTypeName(type);
         };
+    }
+
+    Map<String, TypeName> inheritedTypeVariables(String internalName, String methodName, String descriptor,
+                                                 String signature) {
+        if (signature == null) return Map.of();
+        SignatureVariables methodVariables = signatureVariables(signature);
+        Set<String> unresolved = new LinkedHashSet<>(methodVariables.referenced);
+        unresolved.removeAll(methodVariables.declared);
+        unresolved.removeAll(visibleTypeParameters(internalName));
+        if (unresolved.isEmpty()) return Map.of();
+
+        Map<String, TypeName> result = new LinkedHashMap<>();
+        collectInheritedTypeVariables(classes.get(internalName).node, methodName, descriptor, Map.of(),
+                unresolved, new LinkedHashSet<>(), result);
+        if (!result.keySet().containsAll(unresolved)) {
+            Set<String> missing = new LinkedHashSet<>(unresolved);
+            missing.removeAll(result.keySet());
+            throw failure(internalName + "#" + methodName,
+                    "Cannot resolve inherited type variables " + missing + " for "
+                            + identifier(internalName) + "#" + methodName);
+        }
+        return Map.copyOf(result);
+    }
+
+    private Set<String> visibleTypeParameters(String internalName) {
+        Set<String> result = new LinkedHashSet<>();
+        ClassData current = classes.get(internalName);
+        while (current != null) {
+            result.addAll(signatureVariables(current.node.signature).declared);
+            if ((current.declarationAccess & Opcodes.ACC_STATIC) != 0) break;
+            current = classes.get(current.outerName);
+        }
+        return result;
+    }
+
+    private void collectInheritedTypeVariables(ClassNode node, String methodName, String descriptor,
+                                               Map<String, TypeName> bindings, Set<String> unresolved,
+                                               Set<String> visited, Map<String, TypeName> result) {
+        for (InheritedSupertype inherited : directSupertypes(node, bindings)) {
+            ClassNode parent = classMetadata(inherited.internalName);
+            if (parent == null) continue;
+            Map<String, TypeName> parentBindings = bindTypeParameters(parent, inherited.type);
+            String visitKey = parent.name + parentBindings;
+            if (!visited.add(visitKey)) continue;
+
+            MethodNode inheritedMethod = parent.methods.stream()
+                    .filter(method -> methodName.equals(method.name) && descriptor.equals(method.desc))
+                    .findFirst()
+                    .orElse(null);
+            if (inheritedMethod != null) {
+                Set<String> inheritedVariables = signatureVariables(inheritedMethod.signature).referenced;
+                for (String variable : unresolved) {
+                    if (!inheritedVariables.contains(variable) || !parentBindings.containsKey(variable)) continue;
+                    TypeName previous = result.putIfAbsent(variable, parentBindings.get(variable));
+                    if (previous != null && !previous.equals(parentBindings.get(variable))) {
+                        throw failure(node.name + "#" + methodName,
+                                "Inherited declarations resolve type variable " + variable + " inconsistently");
+                    }
+                }
+            }
+            collectInheritedTypeVariables(parent, methodName, descriptor, parentBindings, unresolved, visited, result);
+        }
+    }
+
+    private List<InheritedSupertype> directSupertypes(ClassNode node, Map<String, TypeName> bindings) {
+        List<String> names = new ArrayList<>();
+        if (node.superName != null) names.add(node.superName);
+        names.addAll(node.interfaces);
+
+        List<TypeName> types = new ArrayList<>();
+        if (node.signature == null) {
+            names.stream().map(this::toClassName).forEach(types::add);
+        } else {
+            Function<String, TypeName> resolver = name -> bindings.getOrDefault(name, TypeVariableName.get(name));
+            FormalParameterParser visitor = new FormalParameterParser(this::toClassName, resolver) {
+                @Override
+                public SignatureVisitor visitSuperclass() {
+                    return supertypeCollector(types, resolver);
+                }
+
+                @Override
+                public SignatureVisitor visitInterface() {
+                    return supertypeCollector(types, resolver);
+                }
+            };
+            new SignatureReader(node.signature).accept(visitor);
+        }
+        if (names.size() != types.size()) {
+            throw failure(node.name, "Could not align inherited generic signatures for " + identifier(node.name));
+        }
+
+        List<InheritedSupertype> result = new ArrayList<>(names.size());
+        for (int index = 0; index < names.size(); index++) {
+            result.add(new InheritedSupertype(names.get(index), types.get(index)));
+        }
+        return result;
+    }
+
+    private TypeSignatureParser supertypeCollector(List<TypeName> types, Function<String, TypeName> resolver) {
+        return new TypeSignatureParser(this::toClassName, resolver) {
+            @Override
+            void finished(TypeName result) {
+                types.add(result);
+            }
+        };
+    }
+
+    private ClassNode classMetadata(String internalName) {
+        ClassData local = classes.get(internalName);
+        return local == null ? readReferencedClass(internalName) : local.node;
+    }
+
+    private static Map<String, TypeName> bindTypeParameters(ClassNode node, TypeName inheritedType) {
+        List<String> parameters = List.copyOf(signatureVariables(node.signature).declared);
+        if (!(inheritedType instanceof ParameterizedTypeName parameterized) || parameters.isEmpty()) return Map.of();
+        if (parameters.size() != parameterized.typeArguments.size()) return Map.of();
+        Map<String, TypeName> result = new LinkedHashMap<>();
+        for (int index = 0; index < parameters.size(); index++) {
+            result.put(parameters.get(index), parameterized.typeArguments.get(index));
+        }
+        return result;
+    }
+
+    private static SignatureVariables signatureVariables(String signature) {
+        SignatureVariables result = new SignatureVariables();
+        if (signature == null) return result;
+        SignatureVisitor visitor = new SignatureVisitor(Opcodes.ASM9) {
+            @Override
+            public void visitFormalTypeParameter(String name) {
+                result.declared.add(name);
+            }
+
+            @Override
+            public void visitTypeVariable(String name) {
+                result.referenced.add(name);
+            }
+        };
+        new SignatureReader(signature).accept(visitor);
+        return result;
     }
 
     private ClassData readRoot(Path classFile) throws IOException {
@@ -508,6 +651,21 @@ final class SpecConverter {
     private static String simpleBinaryName(String internalName) {
         int separator = internalName.lastIndexOf('/');
         return separator < 0 ? internalName : internalName.substring(separator + 1);
+    }
+
+    private static final class InheritedSupertype {
+        private final String internalName;
+        private final TypeName type;
+
+        private InheritedSupertype(String internalName, TypeName type) {
+            this.internalName = internalName;
+            this.type = type;
+        }
+    }
+
+    private static final class SignatureVariables {
+        private final Set<String> declared = new LinkedHashSet<>();
+        private final Set<String> referenced = new LinkedHashSet<>();
     }
 
     private static final class ClassData {

--- a/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/SpecConverter.java
+++ b/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/SpecConverter.java
@@ -266,29 +266,37 @@ final class SpecConverter {
                                                Map<String, TypeName> bindings, Set<String> unresolved,
                                                Set<String> visited, Map<String, TypeName> result) {
         for (InheritedSupertype inherited : directSupertypes(node, bindings)) {
-            ClassNode parent = classMetadata(inherited.internalName);
-            if (parent == null) continue;
-            Map<String, TypeName> parentBindings = bindTypeParameters(parent, inherited.type);
-            String visitKey = parent.name + parentBindings;
-            if (!visited.add(visitKey)) continue;
+            collectInheritedTypeVariablesFromSupertype(node, inherited, methodName, descriptor,
+                    unresolved, visited, result);
+        }
+    }
 
-            MethodNode inheritedMethod = parent.methods.stream()
-                    .filter(method -> methodName.equals(method.name) && descriptor.equals(method.desc))
-                    .findFirst()
-                    .orElse(null);
-            if (inheritedMethod != null) {
-                Set<String> inheritedVariables = signatureVariables(inheritedMethod.signature).referenced;
-                for (String variable : unresolved) {
-                    if (!inheritedVariables.contains(variable) || !parentBindings.containsKey(variable)) continue;
-                    TypeName previous = result.putIfAbsent(variable, parentBindings.get(variable));
-                    if (previous != null && !previous.equals(parentBindings.get(variable))) {
-                        throw failure(node.name + "#" + methodName,
-                                "Inherited declarations resolve type variable " + variable + " inconsistently");
-                    }
+    private void collectInheritedTypeVariablesFromSupertype(ClassNode node, InheritedSupertype inherited,
+                                                            String methodName, String descriptor,
+                                                            Set<String> unresolved, Set<String> visited,
+                                                            Map<String, TypeName> result) {
+        ClassNode parent = classMetadata(inherited.internalName);
+        if (parent == null) return;
+        Map<String, TypeName> parentBindings = bindTypeParameters(parent, inherited.type);
+        String visitKey = parent.name + parentBindings;
+        if (!visited.add(visitKey)) return;
+
+        MethodNode inheritedMethod = parent.methods.stream()
+                .filter(method -> methodName.equals(method.name) && descriptor.equals(method.desc))
+                .findFirst()
+                .orElse(null);
+        if (inheritedMethod != null) {
+            Set<String> inheritedVariables = signatureVariables(inheritedMethod.signature).referenced;
+            for (String variable : unresolved) {
+                if (!inheritedVariables.contains(variable) || !parentBindings.containsKey(variable)) continue;
+                TypeName previous = result.putIfAbsent(variable, parentBindings.get(variable));
+                if (previous != null && !previous.equals(parentBindings.get(variable))) {
+                    throw failure(node.name + "#" + methodName,
+                            "Inherited declarations resolve type variable " + variable + " inconsistently");
                 }
             }
-            collectInheritedTypeVariables(parent, methodName, descriptor, parentBindings, unresolved, visited, result);
         }
+        collectInheritedTypeVariables(parent, methodName, descriptor, parentBindings, unresolved, visited, result);
     }
 
     private List<InheritedSupertype> directSupertypes(ClassNode node, Map<String, TypeName> bindings) {

--- a/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/TypeSignatureParser.java
+++ b/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/TypeSignatureParser.java
@@ -39,7 +39,7 @@ abstract class TypeSignatureParser extends SignatureVisitor {
     }
 
     protected TypeSignatureParser(Function<String, ClassName> classNameResolver) {
-        this(classNameResolver, name -> TypeVariableName.get(name));
+        this(classNameResolver, TypeVariableName::get);
     }
 
     protected TypeSignatureParser(Function<String, ClassName> classNameResolver,
@@ -111,7 +111,7 @@ abstract class TypeSignatureParser extends SignatureVisitor {
     @Override
     public void visitInnerClassType(final String name) {
         TypeName owner = currentType();
-        enclosingType = owner instanceof ParameterizedTypeName ? (ParameterizedTypeName) owner : null;
+        enclosingType = owner instanceof ParameterizedTypeName parameterized ? parameterized : null;
         internalName += "$" + name;
         rawType = classNameResolver.apply(internalName);
         arguments.clear();

--- a/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/TypeSignatureParser.java
+++ b/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/TypeSignatureParser.java
@@ -39,8 +39,14 @@ abstract class TypeSignatureParser extends SignatureVisitor {
     }
 
     protected TypeSignatureParser(Function<String, ClassName> classNameResolver) {
+        this(classNameResolver, name -> TypeVariableName.get(name));
+    }
+
+    protected TypeSignatureParser(Function<String, ClassName> classNameResolver,
+                                  Function<String, TypeName> typeVariableResolver) {
         super(CompilerConfiguration.ASM_API_VERSION);
         this.classNameResolver = Objects.requireNonNull(classNameResolver, "classNameResolver");
+        this.typeVariableResolver = Objects.requireNonNull(typeVariableResolver, "typeVariableResolver");
     }
 
     abstract void finished(TypeName result);
@@ -50,10 +56,11 @@ abstract class TypeSignatureParser extends SignatureVisitor {
     private ParameterizedTypeName enclosingType;
     private final List<TypeName> arguments = new ArrayList<>();
     private final Function<String, ClassName> classNameResolver;
+    private final Function<String, TypeName> typeVariableResolver;
 
     @Override
     public void visitTypeVariable(final String name) {
-        finished(TypeVariableName.get(name));
+        finished(typeVariableResolver.apply(name));
     }
 
     @Override
@@ -64,7 +71,7 @@ abstract class TypeSignatureParser extends SignatureVisitor {
     @Override
     public SignatureVisitor visitArrayType() {
         final TypeSignatureParser outer = this;
-        return new TypeSignatureParser(classNameResolver) {
+        return new TypeSignatureParser(classNameResolver, typeVariableResolver) {
             @Override
             void finished(TypeName result) {
                 outer.finished(ArrayTypeName.of(result));
@@ -85,7 +92,7 @@ abstract class TypeSignatureParser extends SignatureVisitor {
 
     @Override
     public SignatureVisitor visitTypeArgument(final char wildcard) {
-        return new TypeSignatureParser(classNameResolver) {
+        return new TypeSignatureParser(classNameResolver, typeVariableResolver) {
             @Override
             void finished(TypeName result) {
                 if (wildcard == INSTANCEOF) {

--- a/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/TypeSignatureParser.java
+++ b/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/TypeSignatureParser.java
@@ -45,7 +45,9 @@ abstract class TypeSignatureParser extends SignatureVisitor {
 
     abstract void finished(TypeName result);
 
-    private String baseName;
+    private String internalName;
+    private ClassName rawType;
+    private ParameterizedTypeName enclosingType;
     private final List<TypeName> arguments = new ArrayList<>();
     private final Function<String, ClassName> classNameResolver;
 
@@ -72,7 +74,8 @@ abstract class TypeSignatureParser extends SignatureVisitor {
 
     @Override
     public void visitClassType(final String name) {
-        baseName = name;
+        internalName = name;
+        rawType = classNameResolver.apply(name);
     }
 
     @Override
@@ -100,18 +103,24 @@ abstract class TypeSignatureParser extends SignatureVisitor {
 
     @Override
     public void visitInnerClassType(final String name) {
-        baseName += "$" + name;
+        TypeName owner = currentType();
+        enclosingType = owner instanceof ParameterizedTypeName ? (ParameterizedTypeName) owner : null;
+        internalName += "$" + name;
+        rawType = classNameResolver.apply(internalName);
         arguments.clear();
     }
 
     @Override
     public void visitEnd() {
-        ClassName baseType = classNameResolver.apply(baseName);
-        if (arguments.isEmpty()) {
-            finished(baseType);
-        } else {
-            finished(ParameterizedTypeName.get(baseType, arguments.toArray(new TypeName[0])));
+        finished(currentType());
+    }
+
+    private TypeName currentType() {
+        if (enclosingType != null) {
+            return enclosingType.nestedClass(rawType.simpleName(), arguments);
         }
+        if (arguments.isEmpty()) return rawType;
+        return ParameterizedTypeName.get(rawType, arguments.toArray(new TypeName[0]));
     }
 
     private static TypeName toTypeName(char descriptor) {

--- a/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/SourceProjectorTest.groovy
+++ b/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/SourceProjectorTest.groovy
@@ -386,6 +386,48 @@ public class DeepNestedFixture {
         compilation.status() == Compilation.Status.SUCCESS
     }
 
+    def "inherited generic API projections retain their enclosing type context"() {
+        given:
+        compile('''
+            package dummy;
+            import java.util.List;
+            public class InheritedGenericFixture<T extends Comparable<? super T>> {
+                public class Nested<U> {
+                }
+
+                public interface Api<V extends Comparable<? super V>> {
+                    InheritedGenericFixture<V>.Nested<? extends V> inherited(List<? extends V> values);
+                }
+
+                public class Implementation implements Api<T> {
+                    @Override
+                    public InheritedGenericFixture<T>.Nested<? extends T> inherited(List<? extends T> values) {
+                        return null;
+                    }
+                }
+            }
+        ''')
+        SourceProjector projector = new SourceProjector(ProjectionPolicy.documentation())
+
+        when:
+        String source = projector.projectToText(file.toPath())
+
+        then: 'the relevant projection is deterministic'
+        projector.projectToText(file.toPath()) == source
+
+        when: 'the projected declaration is compiled as the semantic validity oracle'
+        compile(source)
+
+        then:
+        compilation.status() == Compilation.Status.SUCCESS
+
+        and: 'exact assertions independently specify the required generic structure'
+        source.contains('class InheritedGenericFixture<T extends Comparable<? super T>>')
+        source.contains('class Implementation implements Api<T>')
+        source.contains('InheritedGenericFixture<V>.Nested<? extends V> inherited(List<? extends V> values)')
+        source.contains('InheritedGenericFixture<T>.Nested<? extends T> inherited(List<? extends T> values)')
+    }
+
     def "semantic top-level names retain legal dollar characters"() {
         given:
         compile('''

--- a/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/SourceProjectorTest.groovy
+++ b/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/SourceProjectorTest.groovy
@@ -24,7 +24,10 @@
 package com.blackbuild.annodocimal.generator
 
 import com.google.testing.compile.Compilation
+import org.objectweb.asm.ClassReader
+import org.objectweb.asm.ClassVisitor
 import org.objectweb.asm.ClassWriter
+import org.objectweb.asm.MethodVisitor
 import org.objectweb.asm.Opcodes
 
 import java.nio.charset.StandardCharsets
@@ -426,6 +429,70 @@ public class DeepNestedFixture {
         source.contains('class Implementation implements Api<T>')
         source.contains('InheritedGenericFixture<V>.Nested<? extends V> inherited(List<? extends V> values)')
         source.contains('InheritedGenericFixture<T>.Nested<? extends T> inherited(List<? extends T> values)')
+    }
+
+    def "inherited generic method signatures resolve their interface type variables"() {
+        given:
+        compile('''
+            package dummy;
+            import java.util.List;
+            public class InheritedGenericMethodFixture {
+                public static class Owner<T extends Comparable<? super T>> {
+                    public class Nested<U> {
+                    }
+                }
+
+                public interface Api<T extends Comparable<? super T>> {
+                    Owner<T>.Nested<? extends T> inherited(List<? extends T> values);
+                }
+
+                public static final class Value implements Comparable<Value> {
+                    @Override
+                    public int compareTo(Value other) {
+                        return 0;
+                    }
+                }
+
+                public static final class Implementation implements Api<Value> {
+                    @Override
+                    public Owner<Value>.Nested<? extends Value> inherited(List<? extends Value> values) {
+                        return null;
+                    }
+                }
+            }
+        ''')
+        def implementationClass = file.toPath().resolveSibling('InheritedGenericMethodFixture$Implementation.class')
+        ClassReader reader = new ClassReader(Files.readAllBytes(implementationClass))
+        ClassWriter writer = new ClassWriter(reader, 0)
+        reader.accept(new ClassVisitor(Opcodes.ASM9, writer) {
+            @Override
+            MethodVisitor visitMethod(int access, String name, String descriptor, String signature,
+                                      String[] exceptions) {
+                if (name == 'inherited') {
+                    signature = '(Ljava/util/List<+TT;>;)Ldummy/InheritedGenericMethodFixture$Owner<TT;>.Nested<+TT;>;'
+                }
+                return super.visitMethod(access, name, descriptor, signature, exceptions)
+            }
+        }, 0)
+        Files.write(implementationClass, writer.toByteArray())
+        SourceProjector projector = new SourceProjector(ProjectionPolicy.documentation())
+
+        when:
+        String source = projector.projectToText(file.toPath())
+
+        then: 'the relevant projection is deterministic'
+        projector.projectToText(file.toPath()) == source
+
+        when: 'the inherited type variable is resolved before the projected declaration is compiled'
+        compile(source)
+
+        then:
+        compilation.status() == Compilation.Status.SUCCESS
+
+        and: 'the inherited interface substitution retains its owner, nesting, bound, and wildcard context'
+        source.contains('interface Api<T extends Comparable<? super T>>')
+        source.contains('class Implementation implements Api<Value>')
+        source.contains('Owner<Value>.Nested<? extends Value> inherited(List<? extends Value> values)')
     }
 
     def "semantic top-level names retain legal dollar characters"() {

--- a/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/SourceProjectorTest.groovy
+++ b/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/SourceProjectorTest.groovy
@@ -29,6 +29,7 @@ import org.objectweb.asm.ClassVisitor
 import org.objectweb.asm.ClassWriter
 import org.objectweb.asm.MethodVisitor
 import org.objectweb.asm.Opcodes
+import spock.lang.Issue
 
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
@@ -389,6 +390,7 @@ public class DeepNestedFixture {
         compilation.status() == Compilation.Status.SUCCESS
     }
 
+    @Issue("32")
     def "inherited generic API projections retain their enclosing type context"() {
         given:
         compile('''
@@ -431,6 +433,7 @@ public class DeepNestedFixture {
         source.contains('InheritedGenericFixture<T>.Nested<? extends T> inherited(List<? extends T> values)')
     }
 
+    @Issue("32")
     def "inherited generic method signatures resolve their interface type variables"() {
         given:
         compile('''

--- a/docs/source-projection.md
+++ b/docs/source-projection.md
@@ -51,7 +51,9 @@ and import layout are likewise not preserved.
 
 Generic signatures retain the declaration context needed to resolve every type variable. In particular, a nested member
 type reached through a parameterized enclosing type keeps that owner qualification in method, field, superclass, and
-interface signatures, including inherited signatures with bounds and wildcards.
+interface signatures, including inherited signatures with bounds and wildcards. When implementation bytecode retains a
+type variable declared by an inherited API, projection resolves it through the parameterized superclass or interface
+path before rendering the implementation signature.
 
 ## Failures
 

--- a/docs/source-projection.md
+++ b/docs/source-projection.md
@@ -49,6 +49,10 @@ not promise original bodies or initializers: deterministic default statements an
 requires them for a valid stub. Synthetic implementation details under the documentation preset, original whitespace,
 and import layout are likewise not preserved.
 
+Generic signatures retain the declaration context needed to resolve every type variable. In particular, a nested member
+type reached through a parameterized enclosing type keeps that owner qualification in method, field, superclass, and
+interface signatures, including inherited signatures with bounds and wildcards.
+
 ## Failures
 
 Ordinary class-input and managed-output file-system failures are `IOException`. A readable class whose selected


### PR DESCRIPTION
## Summary

- preserve parameterized enclosing owners when projecting nested generic types
- resolve inherited method type variables through parameterized superclass and interface relationships
- add issue-linked native regressions that compile the generated Java and cover declarations, bounds, owners, nesting, interfaces, wildcards, and inherited signatures
- document the corrected source-projection contract and release-note impact

## Root cause

Projection reconstructed nested types without retaining their parameterized enclosing owner and rendered inherited method signatures without resolving variables declared by an ancestor type. The resulting Java could therefore contain an undeclared type variable such as `T`.

## Impact

`SourceProjector` now emits compilable Java for inherited generic API shapes while preserving the inclusion and signature-closure policy introduced by #39. This remains focused on #32 and does not absorb the broader projection matrix owned by #41 or inherited-documentation resolution from #10.

## Validation

- focused generator/projection tests on Groovy 3, 4, and 5
- generated-source recompilation regression
- final root `./gradlew check`
- Standards and Spec reviews against the branch base, with no remaining findings

Closes #32
