### PR TITLE
Build recompiling source-projection contract suite (#41)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Added a recompiling Java and Groovy source-projection contract matrix across Groovy 3, 4, and 5. Representative
+  declarations now verify deterministic, compilable output for classes, interfaces, annotations, enums, top-level and
+  nested records, members, generic and wildcard signatures, arrays, declared exceptions, and documentation carriers.
+  Record projections retain record kind and components, and generic declarations no longer lose non-generic declared
+  exceptions.
+
 - Normalized projected annotation members lexicographically by name, including primitive, enum, class, nested-annotation,
   and array-valued members. Repeated projection is byte-identical across Groovy 3, 4, and 5 without treating incidental
   source or bytecode declaration order as Java semantics.

--- a/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/JavaPoetClassVisitor.java
+++ b/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/JavaPoetClassVisitor.java
@@ -53,6 +53,8 @@ class JavaPoetClassVisitor extends ClassVisitor {
     private TypeSpec.Kind kind;
     private boolean record;
     private final List<String> recordComponents = new ArrayList<>();
+    private final List<String> recordComponentDescriptors = new ArrayList<>();
+    private final List<RecordShape> recordShapes = new ArrayList<>();
 
     JavaPoetClassVisitor(SpecConverter specConverter, ProjectionPolicy policy, Set<String> includedClasses,
                          boolean groovyClass, Set<String> groovyRuntimeMethods, Set<String> groovyRuntimeFields) {
@@ -91,6 +93,7 @@ class JavaPoetClassVisitor extends ClassVisitor {
     @Override
     public RecordComponentVisitor visitRecordComponent(String name, String descriptor, String signature) {
         recordComponents.add(name);
+        recordComponentDescriptors.add(descriptor);
         return null;
     }
 
@@ -172,6 +175,7 @@ class JavaPoetClassVisitor extends ClassVisitor {
 
         JavaPoetClassVisitor innerReader = specConverter.readClass(name);
         typeBuilder.addType(innerReader.getType());
+        recordShapes.addAll(innerReader.recordShapes);
 
 
         /*
@@ -198,6 +202,8 @@ class JavaPoetClassVisitor extends ClassVisitor {
 
         Type[] argumentTypes = methodType.getArgumentTypes();
         boolean hasImplicitOuterParameter = hasImplicitOuterParameter(name, argumentTypes);
+        boolean canonicalRecordConstructor = record && name.equals("<init>")
+                && desc.equals("(" + String.join("", recordComponentDescriptors) + ")V");
         List<TypeName> parameterTypes = new ArrayList<>(argumentTypes.length);
         List<String> argumentNames = new ArrayList<>(argumentTypes.length);
         Map<Integer, List<AnnotationSpec>> parameterAnnotations = new HashMap<>();
@@ -322,7 +328,9 @@ class JavaPoetClassVisitor extends ClassVisitor {
             @Override
             public void visitEnd() {
                 for (int i = 0; i < parameterTypes.size(); i++) {
-                    String paramName = argumentNames.size() > i ? argumentNames.get(i) : "param" + i;
+                    String paramName = canonicalRecordConstructor && recordComponents.size() > i
+                            ? recordComponents.get(i)
+                            : argumentNames.size() > i ? argumentNames.get(i) : "param" + i;
                     List<AnnotationSpec> annotations = parameterAnnotations.get(i);
                     ParameterSpec.Builder parameterBuilder = ParameterSpec.builder(parameterTypes.get(i), paramName);
                     if (annotations != null)
@@ -386,6 +394,9 @@ class JavaPoetClassVisitor extends ClassVisitor {
     @Override
     public void visitEnd() {
         type = typeBuilder.build();
+        if (record) {
+            recordShapes.add(new RecordShape(className.simpleName(), List.copyOf(recordComponents)));
+        }
     }
 
     @Override
@@ -492,28 +503,35 @@ class JavaPoetClassVisitor extends ClassVisitor {
     }
 
     String finishSource(String source) {
-        if (!record) return source;
+        for (RecordShape shape : recordShapes) {
+            source = finishRecordSource(source, shape);
+        }
+        return source;
+    }
 
-        String constructorPrefix = "  public " + className.simpleName() + "(";
+    private static String finishRecordSource(String source, RecordShape shape) {
+        String constructorPrefix = "public " + shape.simpleName + "(";
         int constructorStart = source.indexOf(constructorPrefix);
         if (constructorStart < 0) {
-            throw new IllegalStateException("Projected record is missing its canonical constructor: " + className);
+            throw new IllegalStateException("Projected record is missing its canonical constructor: " + shape.simpleName);
         }
         int parametersStart = constructorStart + constructorPrefix.length();
         int parametersEnd = source.indexOf(") {", parametersStart);
         if (parametersEnd < 0) {
-            throw new IllegalStateException("Projected record has an invalid canonical constructor: " + className);
+            throw new IllegalStateException("Projected record has an invalid canonical constructor: " + shape.simpleName);
         }
         String components = source.substring(parametersStart, parametersEnd);
 
-        String classDeclaration = "public final class " + className.simpleName();
-        int declarationStart = source.indexOf(classDeclaration);
+        String classDeclaration = "class " + shape.simpleName;
+        int classStart = source.indexOf(classDeclaration);
+        int declarationStart = source.lastIndexOf('\n', classStart) + 1;
         int declarationEnd = source.indexOf(" {", declarationStart);
-        if (declarationStart < 0 || declarationEnd < 0) {
-            throw new IllegalStateException("Projected record is missing its type declaration: " + className);
+        if (classStart < 0 || declarationEnd < 0) {
+            throw new IllegalStateException("Projected record is missing its type declaration: " + shape.simpleName);
         }
         String declaration = source.substring(declarationStart, declarationEnd);
-        String recordDeclaration = declaration.replace("public final class ", "public record ");
+        String recordDeclaration = declaration.replaceFirst(
+                "\\bfinal class " + Pattern.quote(shape.simpleName) + "\\b", "record " + shape.simpleName);
         int interfacesStart = recordDeclaration.indexOf(" implements ");
         int componentsPosition = interfacesStart < 0 ? recordDeclaration.length() : interfacesStart;
         recordDeclaration = recordDeclaration.substring(0, componentsPosition)
@@ -524,10 +542,14 @@ class JavaPoetClassVisitor extends ClassVisitor {
         constructorStart = source.indexOf(constructorPrefix);
         parametersEnd = source.indexOf(") {", constructorStart + constructorPrefix.length());
         int constructorBody = parametersEnd + 3;
-        String assignments = recordComponents.stream()
-                .map(component -> "    this." + component + " = " + component + ";\n")
+        int constructorLineStart = source.lastIndexOf('\n', constructorStart) + 1;
+        String assignmentIndent = source.substring(constructorLineStart, constructorStart) + "  ";
+        String assignments = shape.components.stream()
+                .map(component -> assignmentIndent + "this." + component + " = " + component + ";\n")
                 .collect(java.util.stream.Collectors.joining());
         return source.substring(0, constructorBody) + "\n" + assignments + source.substring(constructorBody);
     }
+
+    private record RecordShape(String simpleName, List<String> components) {}
 
 }

--- a/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/JavaPoetClassVisitor.java
+++ b/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/JavaPoetClassVisitor.java
@@ -51,6 +51,8 @@ class JavaPoetClassVisitor extends ClassVisitor {
     private String packageName;
     private ClassName className;
     private TypeSpec.Kind kind;
+    private boolean record;
+    private final List<String> recordComponents = new ArrayList<>();
 
     JavaPoetClassVisitor(SpecConverter specConverter, ProjectionPolicy policy, Set<String> includedClasses,
                          boolean groovyClass, Set<String> groovyRuntimeMethods, Set<String> groovyRuntimeFields) {
@@ -66,12 +68,14 @@ class JavaPoetClassVisitor extends ClassVisitor {
     @Override
     public void visit(int version, int access, String name, String signature, String superName, String[] interfaceNames) {
         internalName = name;
+        record = (access & Opcodes.ACC_RECORD) != 0;
         prepareTypeBuilder(access, name);
         if (signature != null) {
-            ClassSignatureParser.parseClassSignature(signature, typeBuilder, kind,
+            ClassSignatureParser.parseClassSignature(signature, typeBuilder,
+                    record ? TypeSpec.Kind.INTERFACE : kind,
                     policy.isGroovyRuntimeArtifactsIncluded() || !groovyClass, specConverter::toClassName);
         } else {
-            if (kind == TypeSpec.Kind.CLASS)
+            if (kind == TypeSpec.Kind.CLASS && !record)
                 typeBuilder.superclass(specConverter.toClassName(superName));
             for (String interf : interfaceNames) {
                 if (groovyClass && !policy.isGroovyRuntimeArtifactsIncluded()
@@ -82,6 +86,12 @@ class JavaPoetClassVisitor extends ClassVisitor {
         }
         int packageSeparator = name.lastIndexOf('/');
         packageName = packageSeparator < 0 ? "" : name.substring(0, packageSeparator).replace('/', '.');
+    }
+
+    @Override
+    public RecordComponentVisitor visitRecordComponent(String name, String descriptor, String signature) {
+        recordComponents.add(name);
+        return null;
     }
 
     private void prepareTypeBuilder(int access, String name) {
@@ -213,7 +223,9 @@ class JavaPoetClassVisitor extends ClassVisitor {
                     return new TypeSignatureParser(specConverter::toClassName, variableResolver) {
                         @Override
                         void finished(TypeName result) {
-                            methodBuilder.returns(result);
+                            if (!name.equals("<init>")) {
+                                methodBuilder.returns(result);
+                            }
                         }
                     };
                 }
@@ -470,6 +482,45 @@ class JavaPoetClassVisitor extends ClassVisitor {
 
     String getPackageName() {
         return packageName;
+    }
+
+    String finishSource(String source) {
+        if (!record) return source;
+
+        String constructorPrefix = "  public " + className.simpleName() + "(";
+        int constructorStart = source.indexOf(constructorPrefix);
+        if (constructorStart < 0) {
+            throw new IllegalStateException("Projected record is missing its canonical constructor: " + className);
+        }
+        int parametersStart = constructorStart + constructorPrefix.length();
+        int parametersEnd = source.indexOf(") {", parametersStart);
+        if (parametersEnd < 0) {
+            throw new IllegalStateException("Projected record has an invalid canonical constructor: " + className);
+        }
+        String components = source.substring(parametersStart, parametersEnd);
+
+        String classDeclaration = "public final class " + className.simpleName();
+        int declarationStart = source.indexOf(classDeclaration);
+        int declarationEnd = source.indexOf(" {", declarationStart);
+        if (declarationStart < 0 || declarationEnd < 0) {
+            throw new IllegalStateException("Projected record is missing its type declaration: " + className);
+        }
+        String declaration = source.substring(declarationStart, declarationEnd);
+        String recordDeclaration = declaration.replace("public final class ", "public record ");
+        int interfacesStart = recordDeclaration.indexOf(" implements ");
+        int componentsPosition = interfacesStart < 0 ? recordDeclaration.length() : interfacesStart;
+        recordDeclaration = recordDeclaration.substring(0, componentsPosition)
+                + "(" + components + ")"
+                + recordDeclaration.substring(componentsPosition);
+        source = source.substring(0, declarationStart) + recordDeclaration + source.substring(declarationEnd);
+
+        constructorStart = source.indexOf(constructorPrefix);
+        parametersEnd = source.indexOf(") {", constructorStart + constructorPrefix.length());
+        int constructorBody = parametersEnd + 3;
+        String assignments = recordComponents.stream()
+                .map(component -> "    this." + component + " = " + component + ";\n")
+                .collect(java.util.stream.Collectors.joining());
+        return source.substring(0, constructorBody) + "\n" + assignments + source.substring(constructorBody);
     }
 
 }

--- a/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/JavaPoetClassVisitor.java
+++ b/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/JavaPoetClassVisitor.java
@@ -41,6 +41,7 @@ import static java.util.stream.Collectors.toSet;
 
 class JavaPoetClassVisitor extends ClassVisitor {
     static final String ANNO_DOC_CLASS = "com.blackbuild.annodocimal.annotations.AnnoDoc";
+    private static final String CONSTRUCTOR_NAME = "<init>";
     private final SpecConverter specConverter;
     private final ProjectionPolicy policy;
     private final Set<String> includedClasses;
@@ -53,7 +54,7 @@ class JavaPoetClassVisitor extends ClassVisitor {
     private String packageName;
     private ClassName className;
     private TypeSpec.Kind kind;
-    private boolean record;
+    private boolean recordDeclaration;
     private final List<RecordComponentShape> recordComponents = new ArrayList<>();
     private final List<RecordShape> recordShapes = new ArrayList<>();
 
@@ -71,14 +72,14 @@ class JavaPoetClassVisitor extends ClassVisitor {
     @Override
     public void visit(int version, int access, String name, String signature, String superName, String[] interfaceNames) {
         internalName = name;
-        record = (access & Opcodes.ACC_RECORD) != 0;
+        recordDeclaration = (access & Opcodes.ACC_RECORD) != 0;
         prepareTypeBuilder(access, name);
         if (signature != null) {
             ClassSignatureParser.parseClassSignature(signature, typeBuilder,
-                    record ? TypeSpec.Kind.INTERFACE : kind,
+                    recordDeclaration ? TypeSpec.Kind.INTERFACE : kind,
                     policy.isGroovyRuntimeArtifactsIncluded() || !groovyClass, specConverter::toClassName);
         } else {
-            if (kind == TypeSpec.Kind.CLASS && !record)
+            if (kind == TypeSpec.Kind.CLASS && !recordDeclaration)
                 typeBuilder.superclass(specConverter.toClassName(superName));
             for (String interf : interfaceNames) {
                 if (groovyClass && !policy.isGroovyRuntimeArtifactsIncluded()
@@ -213,7 +214,7 @@ class JavaPoetClassVisitor extends ClassVisitor {
 
         Type[] argumentTypes = methodType.getArgumentTypes();
         boolean hasImplicitOuterParameter = hasImplicitOuterParameter(name, argumentTypes);
-        boolean canonicalRecordConstructor = record && name.equals("<init>")
+        boolean canonicalRecordConstructor = recordDeclaration && name.equals(CONSTRUCTOR_NAME)
                 && desc.equals("(" + recordComponents.stream()
                 .map(RecordComponentShape::descriptor)
                 .collect(joining()) + ")V");
@@ -243,7 +244,7 @@ class JavaPoetClassVisitor extends ClassVisitor {
                     return new TypeSignatureParser(specConverter::toClassName, variableResolver) {
                         @Override
                         void finished(TypeName result) {
-                            if (!name.equals("<init>")) {
+                            if (!name.equals(CONSTRUCTOR_NAME)) {
                                 methodBuilder.returns(result);
                             }
                         }
@@ -273,7 +274,7 @@ class JavaPoetClassVisitor extends ClassVisitor {
                 }
             }
         } else {
-            if (!name.equals("<init>")) {
+            if (!name.equals(CONSTRUCTOR_NAME)) {
                 methodBuilder.returns(specConverter.toTypeName(methodType.getReturnType()));
             }
             int firstSourceParameter = hasImplicitOuterParameter ? 1 : 0;
@@ -341,9 +342,14 @@ class JavaPoetClassVisitor extends ClassVisitor {
             @Override
             public void visitEnd() {
                 for (int i = 0; i < parameterTypes.size(); i++) {
-                    String paramName = canonicalRecordConstructor && recordComponents.size() > i
-                            ? recordComponents.get(i).name()
-                            : argumentNames.size() > i ? argumentNames.get(i) : "param" + i;
+                    String paramName;
+                    if (canonicalRecordConstructor && recordComponents.size() > i) {
+                        paramName = recordComponents.get(i).name();
+                    } else if (argumentNames.size() > i) {
+                        paramName = argumentNames.get(i);
+                    } else {
+                        paramName = "param" + i;
+                    }
                     List<AnnotationSpec> annotations = parameterAnnotations.get(i);
                     ParameterSpec.Builder parameterBuilder = ParameterSpec.builder(parameterTypes.get(i), paramName);
                     if (annotations != null)
@@ -356,7 +362,8 @@ class JavaPoetClassVisitor extends ClassVisitor {
                     methodBuilder.addJavadoc(filterParams(extractedJavadoc));
                 }
 
-                boolean requiresReturn = !"<init>".equals(name) && methodType.getReturnType().getSort() != Type.VOID
+                boolean requiresReturn = !CONSTRUCTOR_NAME.equals(name)
+                        && methodType.getReturnType().getSort() != Type.VOID
                         && !methodBuilder.modifiers.contains(Modifier.ABSTRACT)
                         && !methodBuilder.modifiers.contains(Modifier.NATIVE);
                 if (requiresReturn) {
@@ -397,7 +404,7 @@ class JavaPoetClassVisitor extends ClassVisitor {
     }
 
     private boolean hasImplicitOuterParameter(String methodName, Type[] argumentTypes) {
-        if (!"<init>".equals(methodName) || typeBuilder.modifiers.contains(Modifier.STATIC)
+        if (!CONSTRUCTOR_NAME.equals(methodName) || typeBuilder.modifiers.contains(Modifier.STATIC)
                 || className.enclosingClassName() == null || argumentTypes.length == 0) {
             return false;
         }
@@ -407,7 +414,7 @@ class JavaPoetClassVisitor extends ClassVisitor {
     @Override
     public void visitEnd() {
         type = typeBuilder.build();
-        if (record) {
+        if (recordDeclaration) {
             recordShapes.add(new RecordShape(className.simpleName(), List.copyOf(recordComponents)));
         }
     }
@@ -547,25 +554,13 @@ class JavaPoetClassVisitor extends ClassVisitor {
 
         String constructorToken = shape.simpleName() + "(";
         int recordBodyStart = source.indexOf(" {", declarationStart) + 2;
-        int constructorStart = source.indexOf(constructorToken, recordBodyStart);
-        int parametersEnd = -1;
-        while (constructorStart >= 0) {
-            int candidateEnd = source.indexOf(") {", constructorStart + constructorToken.length());
-            if (candidateEnd < 0) break;
-            String candidateParameters = source.substring(
-                    constructorStart + constructorToken.length(), candidateEnd).replaceAll("\\s+", " ").trim();
-            if (candidateParameters.equals(components.replaceAll("\\s+", " ").trim())) {
-                parametersEnd = candidateEnd;
-                break;
-            }
-            constructorStart = source.indexOf(constructorToken, candidateEnd);
-        }
-        if (constructorStart < 0 || parametersEnd < 0) return source;
+        ConstructorRange constructor = findCanonicalConstructor(source, constructorToken, recordBodyStart, components);
+        if (constructor == null) return source;
 
-        int constructorBody = parametersEnd + 3;
-        int constructorLineStart = source.lastIndexOf('\n', constructorStart) + 1;
+        int constructorBody = constructor.parametersEnd() + 3;
+        int constructorLineStart = source.lastIndexOf('\n', constructor.start()) + 1;
         int indentationEnd = constructorLineStart;
-        while (indentationEnd < constructorStart && Character.isWhitespace(source.charAt(indentationEnd))) {
+        while (indentationEnd < constructor.start() && Character.isWhitespace(source.charAt(indentationEnd))) {
             indentationEnd++;
         }
         String assignmentIndent = source.substring(constructorLineStart, indentationEnd) + "  ";
@@ -574,6 +569,27 @@ class JavaPoetClassVisitor extends ClassVisitor {
                         + " = " + component.name() + ";\n")
                 .collect(joining());
         return source.substring(0, constructorBody) + "\n" + assignments + source.substring(constructorBody);
+    }
+
+    private static ConstructorRange findCanonicalConstructor(String source, String constructorToken,
+                                                              int searchStart, String components) {
+        String normalizedComponents = normalizeParameters(components);
+        int constructorStart = source.indexOf(constructorToken, searchStart);
+        while (constructorStart >= 0) {
+            int parametersEnd = source.indexOf(") {", constructorStart + constructorToken.length());
+            if (parametersEnd < 0) return null;
+            String candidateParameters = source.substring(
+                    constructorStart + constructorToken.length(), parametersEnd);
+            if (normalizeParameters(candidateParameters).equals(normalizedComponents)) {
+                return new ConstructorRange(constructorStart, parametersEnd);
+            }
+            constructorStart = source.indexOf(constructorToken, parametersEnd);
+        }
+        return null;
+    }
+
+    private static String normalizeParameters(String parameters) {
+        return parameters.replaceAll("\\s+", " ").trim();
     }
 
     private static String sourceType(TypeName type, String source) {
@@ -589,5 +605,7 @@ class JavaPoetClassVisitor extends ClassVisitor {
     private record RecordComponentShape(String name, String descriptor, TypeName type) {}
 
     private record RecordShape(String simpleName, List<RecordComponentShape> components) {}
+
+    private record ConstructorRange(int start, int parametersEnd) {}
 
 }

--- a/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/JavaPoetClassVisitor.java
+++ b/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/JavaPoetClassVisitor.java
@@ -33,8 +33,10 @@ import javax.lang.model.element.Modifier;
 import java.io.IOException;
 import java.util.*;
 import java.util.function.Function;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toSet;
 
 class JavaPoetClassVisitor extends ClassVisitor {
@@ -52,8 +54,7 @@ class JavaPoetClassVisitor extends ClassVisitor {
     private ClassName className;
     private TypeSpec.Kind kind;
     private boolean record;
-    private final List<String> recordComponents = new ArrayList<>();
-    private final List<String> recordComponentDescriptors = new ArrayList<>();
+    private final List<RecordComponentShape> recordComponents = new ArrayList<>();
     private final List<RecordShape> recordShapes = new ArrayList<>();
 
     JavaPoetClassVisitor(SpecConverter specConverter, ProjectionPolicy policy, Set<String> includedClasses,
@@ -92,8 +93,18 @@ class JavaPoetClassVisitor extends ClassVisitor {
 
     @Override
     public RecordComponentVisitor visitRecordComponent(String name, String descriptor, String signature) {
-        recordComponents.add(name);
-        recordComponentDescriptors.add(descriptor);
+        final TypeName[] componentType = {null};
+        if (signature == null) {
+            componentType[0] = specConverter.toTypeName(Type.getType(descriptor));
+        } else {
+            new SignatureReader(signature).accept(new TypeSignatureParser(specConverter::toClassName) {
+                @Override
+                void finished(TypeName result) {
+                    componentType[0] = result;
+                }
+            });
+        }
+        recordComponents.add(new RecordComponentShape(name, descriptor, componentType[0]));
         return null;
     }
 
@@ -203,7 +214,9 @@ class JavaPoetClassVisitor extends ClassVisitor {
         Type[] argumentTypes = methodType.getArgumentTypes();
         boolean hasImplicitOuterParameter = hasImplicitOuterParameter(name, argumentTypes);
         boolean canonicalRecordConstructor = record && name.equals("<init>")
-                && desc.equals("(" + String.join("", recordComponentDescriptors) + ")V");
+                && desc.equals("(" + recordComponents.stream()
+                .map(RecordComponentShape::descriptor)
+                .collect(joining()) + ")V");
         List<TypeName> parameterTypes = new ArrayList<>(argumentTypes.length);
         List<String> argumentNames = new ArrayList<>(argumentTypes.length);
         Map<Integer, List<AnnotationSpec>> parameterAnnotations = new HashMap<>();
@@ -329,7 +342,7 @@ class JavaPoetClassVisitor extends ClassVisitor {
             public void visitEnd() {
                 for (int i = 0; i < parameterTypes.size(); i++) {
                     String paramName = canonicalRecordConstructor && recordComponents.size() > i
-                            ? recordComponents.get(i)
+                            ? recordComponents.get(i).name()
                             : argumentNames.size() > i ? argumentNames.get(i) : "param" + i;
                     List<AnnotationSpec> annotations = parameterAnnotations.get(i);
                     ParameterSpec.Builder parameterBuilder = ParameterSpec.builder(parameterTypes.get(i), paramName);
@@ -510,28 +523,21 @@ class JavaPoetClassVisitor extends ClassVisitor {
     }
 
     private static String finishRecordSource(String source, RecordShape shape) {
-        String constructorPrefix = "public " + shape.simpleName + "(";
-        int constructorStart = source.indexOf(constructorPrefix);
-        if (constructorStart < 0) {
-            throw new IllegalStateException("Projected record is missing its canonical constructor: " + shape.simpleName);
-        }
-        int parametersStart = constructorStart + constructorPrefix.length();
-        int parametersEnd = source.indexOf(") {", parametersStart);
-        if (parametersEnd < 0) {
-            throw new IllegalStateException("Projected record has an invalid canonical constructor: " + shape.simpleName);
-        }
-        String components = source.substring(parametersStart, parametersEnd);
+        String sourceForTypes = source;
+        String components = shape.components().stream()
+                .map(component -> sourceType(component.type(), sourceForTypes) + " " + component.name())
+                .collect(joining(", "));
 
-        String classDeclaration = "class " + shape.simpleName;
+        String classDeclaration = "class " + shape.simpleName();
         int classStart = source.indexOf(classDeclaration);
         int declarationStart = source.lastIndexOf('\n', classStart) + 1;
         int declarationEnd = source.indexOf(" {", declarationStart);
         if (classStart < 0 || declarationEnd < 0) {
-            throw new IllegalStateException("Projected record is missing its type declaration: " + shape.simpleName);
+            throw new IllegalStateException("Projected record is missing its type declaration: " + shape.simpleName());
         }
         String declaration = source.substring(declarationStart, declarationEnd);
         String recordDeclaration = declaration.replaceFirst(
-                "\\bfinal class " + Pattern.quote(shape.simpleName) + "\\b", "record " + shape.simpleName);
+                "\\bfinal class " + Pattern.quote(shape.simpleName()) + "\\b", "record " + shape.simpleName());
         int interfacesStart = recordDeclaration.indexOf(" implements ");
         int componentsPosition = interfacesStart < 0 ? recordDeclaration.length() : interfacesStart;
         recordDeclaration = recordDeclaration.substring(0, componentsPosition)
@@ -539,17 +545,49 @@ class JavaPoetClassVisitor extends ClassVisitor {
                 + recordDeclaration.substring(componentsPosition);
         source = source.substring(0, declarationStart) + recordDeclaration + source.substring(declarationEnd);
 
-        constructorStart = source.indexOf(constructorPrefix);
-        parametersEnd = source.indexOf(") {", constructorStart + constructorPrefix.length());
+        String constructorToken = shape.simpleName() + "(";
+        int recordBodyStart = source.indexOf(" {", declarationStart) + 2;
+        int constructorStart = source.indexOf(constructorToken, recordBodyStart);
+        int parametersEnd = -1;
+        while (constructorStart >= 0) {
+            int candidateEnd = source.indexOf(") {", constructorStart + constructorToken.length());
+            if (candidateEnd < 0) break;
+            String candidateParameters = source.substring(
+                    constructorStart + constructorToken.length(), candidateEnd).replaceAll("\\s+", " ").trim();
+            if (candidateParameters.equals(components.replaceAll("\\s+", " ").trim())) {
+                parametersEnd = candidateEnd;
+                break;
+            }
+            constructorStart = source.indexOf(constructorToken, candidateEnd);
+        }
+        if (constructorStart < 0 || parametersEnd < 0) return source;
+
         int constructorBody = parametersEnd + 3;
         int constructorLineStart = source.lastIndexOf('\n', constructorStart) + 1;
-        String assignmentIndent = source.substring(constructorLineStart, constructorStart) + "  ";
-        String assignments = shape.components.stream()
-                .map(component -> assignmentIndent + "this." + component + " = " + component + ";\n")
-                .collect(java.util.stream.Collectors.joining());
+        int indentationEnd = constructorLineStart;
+        while (indentationEnd < constructorStart && Character.isWhitespace(source.charAt(indentationEnd))) {
+            indentationEnd++;
+        }
+        String assignmentIndent = source.substring(constructorLineStart, indentationEnd) + "  ";
+        String assignments = shape.components().stream()
+                .map(component -> assignmentIndent + "this." + component.name()
+                        + " = " + component.name() + ";\n")
+                .collect(joining());
         return source.substring(0, constructorBody) + "\n" + assignments + source.substring(constructorBody);
     }
 
-    private record RecordShape(String simpleName, List<String> components) {}
+    private static String sourceType(TypeName type, String source) {
+        String result = type.toString();
+        Matcher imports = Pattern.compile("(?m)^import ([\\w.$]+);$").matcher(source);
+        while (imports.find()) {
+            String importedType = imports.group(1);
+            result = result.replace(importedType, importedType.substring(importedType.lastIndexOf('.') + 1));
+        }
+        return result;
+    }
+
+    private record RecordComponentShape(String name, String descriptor, TypeName type) {}
+
+    private record RecordShape(String simpleName, List<RecordComponentShape> components) {}
 
 }

--- a/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/JavaPoetClassVisitor.java
+++ b/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/JavaPoetClassVisitor.java
@@ -201,6 +201,7 @@ class JavaPoetClassVisitor extends ClassVisitor {
         List<TypeName> parameterTypes = new ArrayList<>(argumentTypes.length);
         List<String> argumentNames = new ArrayList<>(argumentTypes.length);
         Map<Integer, List<AnnotationSpec>> parameterAnnotations = new HashMap<>();
+        List<TypeName> exceptionTypes = new ArrayList<>();
 
         if (signature != null) {
             Map<String, TypeName> inheritedVariables = specConverter.inheritedTypeVariables(
@@ -235,7 +236,7 @@ class JavaPoetClassVisitor extends ClassVisitor {
                     return new TypeSignatureParser(specConverter::toClassName, variableResolver) {
                         @Override
                         void finished(TypeName result) {
-                            methodBuilder.addException(result);
+                            exceptionTypes.add(result);
                         }
                     };
                 }
@@ -247,6 +248,11 @@ class JavaPoetClassVisitor extends ClassVisitor {
             v.getTypeParameters().entrySet().stream()
                     .map(ClassSignatureParser::toTypeVariable)
                     .forEach(methodBuilder::addTypeVariable);
+            if (exceptionTypes.isEmpty() && exceptions != null) {
+                for (String exception : exceptions) {
+                    exceptionTypes.add(specConverter.toClassName(exception));
+                }
+            }
         } else {
             if (!name.equals("<init>")) {
                 methodBuilder.returns(specConverter.toTypeName(methodType.getReturnType()));
@@ -257,9 +263,10 @@ class JavaPoetClassVisitor extends ClassVisitor {
             }
             if (exceptions != null)
                 for (String exception : exceptions) {
-                    methodBuilder.addException(specConverter.toClassName(exception));
+                    exceptionTypes.add(specConverter.toClassName(exception));
                 }
         }
+        exceptionTypes.forEach(methodBuilder::addException);
 
         return new MethodVisitor(api) {
             String extractedJavadoc = null;

--- a/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/SpecConverter.java
+++ b/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/SpecConverter.java
@@ -104,7 +104,8 @@ final class SpecConverter {
             JavaFile javaFile = JavaFile.builder(rootVisitor.getPackageName(), rootVisitor.getType()).build();
             StringBuilder source = new StringBuilder();
             javaFile.writeTo(source);
-            return new SourceProjector.ProjectionResult(converter.root.node.name, source.toString());
+            return new SourceProjector.ProjectionResult(
+                    converter.root.node.name, rootVisitor.finishSource(source.toString()));
         } catch (SourceProjectionException exception) {
             throw exception;
         } catch (RuntimeException exception) {

--- a/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/GroovySourceProjectionContractTest.groovy
+++ b/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/GroovySourceProjectionContractTest.groovy
@@ -23,11 +23,10 @@
  */
 package com.blackbuild.annodocimal.generator
 
-import com.google.testing.compile.Compilation
 import com.google.testing.compile.Compiler
-import com.google.testing.compile.JavaFileObjects
 import spock.lang.Issue
 
+import static com.blackbuild.annodocimal.generator.ProjectionContractAssertions.assertProjectionCompiles
 import static com.google.testing.compile.Compiler.javac
 
 @Issue("41")
@@ -75,6 +74,7 @@ class GroovySourceProjectionContractTest extends ClassGeneratingTest {
         ''')
         def classFile = new File(outputDirectory, 'contract/GroovyDeclarationFixture.class').toPath()
         SourceProjector projector = new SourceProjector(ProjectionPolicy.documentation())
+        Compiler projectionCompiler = javac().withOptions('-parameters')
 
         when:
         String projection = projector.projectToText(classFile)
@@ -133,7 +133,7 @@ public class GroovyDeclarationFixture<T extends Number> {
 '''
 
         and:
-        assertProjectionCompiles(fixture, 'contract.GroovyDeclarationFixture', projection)
+        assertProjectionCompiles(projectionCompiler, fixture, 'contract.GroovyDeclarationFixture', projection)
 
         and: 'exact text checks retain semantics that compilation does not establish'
         projection.contains('/**\n * Canonical Groovy class documentation\n */')
@@ -148,12 +148,5 @@ public class GroovyDeclarationFixture<T extends Number> {
         projection.contains('protected enum Mode')
         projection.contains('@interface Marker')
         projection.contains('String value() default "marker";')
-    }
-
-    private static void assertProjectionCompiles(String fixture, String qualifiedName, String projection) {
-        Compiler compiler = javac().withOptions('-parameters')
-        Compilation result = compiler.compile(JavaFileObjects.forSourceString(qualifiedName, projection))
-        assert result.status() == Compilation.Status.SUCCESS:
-                "Projection fixture '$fixture' failed to compile:\n${result.diagnostics()}\n$projection"
     }
 }

--- a/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/GroovySourceProjectionContractTest.groovy
+++ b/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/GroovySourceProjectionContractTest.groovy
@@ -1,0 +1,159 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2024 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.blackbuild.annodocimal.generator
+
+import com.google.testing.compile.Compilation
+import com.google.testing.compile.Compiler
+import com.google.testing.compile.JavaFileObjects
+import spock.lang.Issue
+
+import static com.google.testing.compile.Compiler.javac
+
+@Issue("41")
+class GroovySourceProjectionContractTest extends ClassGeneratingTest {
+
+    def "representative Groovy declaration projection is deterministic and recompilable"() {
+        given:
+        String fixture = 'groovy-declaration-matrix'
+        createClass('''
+            package contract
+
+            import com.blackbuild.annodocimal.annotations.AnnoDoc
+            import groovy.lang.Groovydoc
+
+            import java.lang.annotation.Retention
+            import java.lang.annotation.RetentionPolicy
+
+            @AnnoDoc('Canonical Groovy class documentation')
+            class GroovyDeclarationFixture<T extends Number> {
+                @AnnoDoc('Canonical Groovy property documentation')
+                T[] values
+
+                GroovyDeclarationFixture(T[] values) throws IllegalArgumentException {
+                    this.values = values
+                }
+
+                List<? extends T> convert(List<? super T> input) throws IOException {
+                    null
+                }
+
+                @Groovydoc('Interoperable nested interface documentation')
+                interface NestedApi<X> {
+                    X apply(X value) throws Exception
+                }
+
+                protected enum Mode {
+                    FAST, SLOW
+                }
+
+                @Retention(RetentionPolicy.RUNTIME)
+                @interface Marker {
+                    String value() default 'marker'
+                }
+            }
+        ''')
+        def classFile = new File(outputDirectory, 'contract/GroovyDeclarationFixture.class').toPath()
+        SourceProjector projector = new SourceProjector(ProjectionPolicy.documentation())
+
+        when:
+        String projection = projector.projectToText(classFile)
+
+        then:
+        projector.projectToText(classFile) == projection
+        projection == '''package contract;
+
+import groovy.lang.Groovydoc;
+import groovy.transform.Generated;
+import java.io.IOException;
+import java.lang.Exception;
+import java.lang.IllegalArgumentException;
+import java.lang.Number;
+import java.lang.String;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.List;
+
+/**
+ * Canonical Groovy class documentation
+ */
+public class GroovyDeclarationFixture<T extends Number> {
+  public GroovyDeclarationFixture(T[] values) throws IllegalArgumentException {
+  }
+
+  public List<? extends T> convert(List<? super T> input) throws IOException {
+    return null;
+  }
+
+  @Generated
+  public T[] getValues() {
+    return null;
+  }
+
+  @Generated
+  public void setValues(T[] value) {
+  }
+
+  @Groovydoc("Interoperable nested interface documentation")
+  public interface NestedApi<X> {
+    X apply(X value) throws Exception;
+  }
+
+  protected enum Mode {
+    FAST,
+
+    SLOW
+  }
+
+  @Retention(RetentionPolicy.RUNTIME)
+  public @interface Marker {
+    String value() default "marker";
+  }
+}
+'''
+
+        and:
+        assertProjectionCompiles(fixture, 'contract.GroovyDeclarationFixture', projection)
+
+        and: 'exact text checks retain semantics that compilation does not establish'
+        projection.contains('/**\n * Canonical Groovy class documentation\n */')
+        projection.contains('class GroovyDeclarationFixture<T extends Number>')
+        projection.contains('public GroovyDeclarationFixture(T[] values) throws IllegalArgumentException')
+        projection.contains('List<? extends T> convert(List<? super T> input) throws IOException')
+        projection.contains('public T[] getValues()')
+        projection.contains('public void setValues(T[] value)')
+        projection.contains('@Groovydoc("Interoperable nested interface documentation")')
+        projection.contains('public interface NestedApi<X>')
+        projection.contains('X apply(X value) throws Exception;')
+        projection.contains('protected enum Mode')
+        projection.contains('@interface Marker')
+        projection.contains('String value() default "marker";')
+    }
+
+    private static void assertProjectionCompiles(String fixture, String qualifiedName, String projection) {
+        Compiler compiler = javac().withOptions('-parameters')
+        Compilation result = compiler.compile(JavaFileObjects.forSourceString(qualifiedName, projection))
+        assert result.status() == Compilation.Status.SUCCESS:
+                "Projection fixture '$fixture' failed to compile:\n${result.diagnostics()}\n$projection"
+    }
+}

--- a/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/ProjectionContractAssertions.groovy
+++ b/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/ProjectionContractAssertions.groovy
@@ -1,0 +1,39 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2024 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.blackbuild.annodocimal.generator
+
+import com.google.testing.compile.Compilation
+import com.google.testing.compile.Compiler
+import com.google.testing.compile.JavaFileObjects
+
+final class ProjectionContractAssertions {
+
+    private ProjectionContractAssertions() {}
+
+    static void assertProjectionCompiles(Compiler compiler, String fixture, String qualifiedName, String projection) {
+        Compilation result = compiler.compile(JavaFileObjects.forSourceString(qualifiedName, projection))
+        assert result.status() == Compilation.Status.SUCCESS:
+                "Projection fixture '$fixture' failed to compile:\n${result.diagnostics()}\n$projection"
+    }
+}

--- a/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/SourceProjectionContractTest.groovy
+++ b/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/SourceProjectionContractTest.groovy
@@ -161,6 +161,7 @@ public class JavaDeclarationFixture<T extends Number & Comparable<T>> {
                     public record RecordFixture<T extends Comparable<? super T>>(T value, String[] aliases)
                             implements Serializable {
                         public static class Metadata {}
+                        public record NestedRecord<U>(U nestedValue) {}
                     }
                 '''
         ], 'contract.RecordFixture')
@@ -177,6 +178,7 @@ public class JavaDeclarationFixture<T extends Number & Comparable<T>> {
 
         and: 'record kind and component semantics are preserved exactly'
         projection.contains('public record RecordFixture<T extends Comparable<? super T>>(T value, String[] aliases)')
+        projection.contains('public static record NestedRecord<U>(U nestedValue)')
     }
 
     private void assertProjectionCompiles(String fixture, String qualifiedName, String projection) {

--- a/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/SourceProjectionContractTest.groovy
+++ b/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/SourceProjectionContractTest.groovy
@@ -23,9 +23,9 @@
  */
 package com.blackbuild.annodocimal.generator
 
-import com.google.testing.compile.Compilation
-import com.google.testing.compile.JavaFileObjects
 import spock.lang.Issue
+
+import static com.blackbuild.annodocimal.generator.ProjectionContractAssertions.assertProjectionCompiles
 
 @Issue("41")
 class SourceProjectionContractTest extends JavaClassGeneratingTest {
@@ -134,7 +134,7 @@ public class JavaDeclarationFixture<T extends Number & Comparable<T>> {
 '''
 
         and:
-        assertProjectionCompiles(fixture, 'contract.JavaDeclarationFixture', projection)
+        assertProjectionCompiles(compiler, fixture, 'contract.JavaDeclarationFixture', projection)
 
         and: 'exact text checks retain semantics that compilation does not establish'
         projection.contains('/**\n * Canonical class documentation\n */')
@@ -162,6 +162,7 @@ public class JavaDeclarationFixture<T extends Number & Comparable<T>> {
                             implements Serializable {
                         public static class Metadata {}
                         public record NestedRecord<U>(U nestedValue) {}
+                        protected record ProtectedRecord<U>(U protectedValue) {}
                     }
                 '''
         ], 'contract.RecordFixture')
@@ -174,16 +175,35 @@ public class JavaDeclarationFixture<T extends Number & Comparable<T>> {
         projector.projectToText(file.toPath()) == projection
 
         and:
-        assertProjectionCompiles(fixture, 'contract.RecordFixture', projection)
+        assertProjectionCompiles(compiler, fixture, 'contract.RecordFixture', projection)
 
         and: 'record kind and component semantics are preserved exactly'
         projection.contains('public record RecordFixture<T extends Comparable<? super T>>(T value, String[] aliases)')
         projection.contains('public static record NestedRecord<U>(U nestedValue)')
+        projection.contains('protected static record ProtectedRecord<U>(U protectedValue)')
     }
 
-    private void assertProjectionCompiles(String fixture, String qualifiedName, String projection) {
-        Compilation result = compiler.compile(JavaFileObjects.forSourceString(qualifiedName, projection))
-        assert result.status() == Compilation.Status.SUCCESS:
-                "Projection fixture '$fixture' failed to compile:\n${result.diagnostics()}\n$projection"
+    def "package-private record roots remain deterministic and recompilable"() {
+        given:
+        String fixture = 'java-package-private-record'
+        compile([
+                'contract.PackageRecordFixture': '''
+                    package contract;
+                    record PackageRecordFixture(int value) {}
+                '''
+        ], 'contract.PackageRecordFixture')
+        SourceProjector projector = new SourceProjector(ProjectionPolicy.documentation())
+
+        when:
+        String projection = projector.projectToText(file.toPath())
+
+        then:
+        projector.projectToText(file.toPath()) == projection
+
+        and:
+        assertProjectionCompiles(compiler, fixture, 'contract.PackageRecordFixture', projection)
+
+        and:
+        projection.contains('record PackageRecordFixture(int value)')
     }
 }

--- a/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/SourceProjectionContractTest.groovy
+++ b/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/SourceProjectionContractTest.groovy
@@ -30,6 +30,74 @@ import spock.lang.Issue
 @Issue("41")
 class SourceProjectionContractTest extends JavaClassGeneratingTest {
 
+    def "representative Java declaration projection is deterministic and recompilable"() {
+        given:
+        String fixture = 'java-declaration-matrix'
+        compile([
+                'contract.JavaDeclarationFixture': '''
+                    package contract;
+
+                    import com.blackbuild.annodocimal.annotations.AnnoDoc;
+                    import java.io.IOException;
+                    import java.lang.annotation.Retention;
+                    import java.lang.annotation.RetentionPolicy;
+                    import java.util.List;
+
+                    @AnnoDoc("Canonical class documentation")
+                    public class JavaDeclarationFixture<T extends Number & Comparable<T>> {
+                        @AnnoDoc("Canonical field documentation")
+                        public T[] values;
+
+                        @AnnoDoc("Canonical constructor documentation")
+                        public JavaDeclarationFixture(T[] values) throws IllegalArgumentException {
+                            this.values = values;
+                        }
+
+                        @AnnoDoc("Canonical method documentation")
+                        public <E extends Exception> List<? extends T>[] convert(List<? super T>[] input)
+                                throws IOException, E {
+                            return null;
+                        }
+
+                        public interface NestedApi<X> {
+                            X apply(X value) throws Exception;
+                        }
+
+                        protected enum Mode {
+                            FAST, SLOW
+                        }
+
+                        @Retention(RetentionPolicy.RUNTIME)
+                        public @interface Marker {
+                            String value() default "marker";
+                        }
+                    }
+                '''
+        ], 'contract.JavaDeclarationFixture')
+        SourceProjector projector = new SourceProjector(ProjectionPolicy.documentation())
+
+        when:
+        String projection = projector.projectToText(file.toPath())
+
+        then:
+        projector.projectToText(file.toPath()) == projection
+
+        and:
+        assertProjectionCompiles(fixture, 'contract.JavaDeclarationFixture', projection)
+
+        and: 'exact text checks retain semantics that compilation does not establish'
+        projection.contains('/**\n * Canonical class documentation\n */')
+        projection.contains('class JavaDeclarationFixture<T extends Number & Comparable<T>>')
+        projection.contains('public T[] values;')
+        projection.contains('public JavaDeclarationFixture(T[] values) throws IllegalArgumentException')
+        projection.contains('public <E extends Exception> List<? extends T>[] convert(List<? super T>[] input) throws\n      IOException, E')
+        projection.contains('public interface NestedApi<X>')
+        projection.contains('X apply(X value) throws Exception;')
+        projection.contains('protected enum Mode')
+        projection.contains('public @interface Marker')
+        projection.contains('String value() default "marker";')
+    }
+
     def "supported Java record projections are deterministic and recompilable"() {
         given:
         String fixture = 'java-record'

--- a/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/SourceProjectionContractTest.groovy
+++ b/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/SourceProjectionContractTest.groovy
@@ -81,6 +81,57 @@ class SourceProjectionContractTest extends JavaClassGeneratingTest {
 
         then:
         projector.projectToText(file.toPath()) == projection
+        projection == '''package contract;
+
+import java.io.IOException;
+import java.lang.Comparable;
+import java.lang.Exception;
+import java.lang.IllegalArgumentException;
+import java.lang.Number;
+import java.lang.String;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.List;
+
+/**
+ * Canonical class documentation
+ */
+public class JavaDeclarationFixture<T extends Number & Comparable<T>> {
+  /**
+   * Canonical field documentation
+   */
+  public T[] values;
+
+  /**
+   * Canonical constructor documentation
+   */
+  public JavaDeclarationFixture(T[] values) throws IllegalArgumentException {
+  }
+
+  /**
+   * Canonical method documentation
+   */
+  public <E extends Exception> List<? extends T>[] convert(List<? super T>[] input) throws
+      IOException, E {
+    return null;
+  }
+
+  @Retention(RetentionPolicy.RUNTIME)
+  public @interface Marker {
+    String value() default "marker";
+  }
+
+  protected enum Mode {
+    FAST,
+
+    SLOW
+  }
+
+  public interface NestedApi<X> {
+    X apply(X value) throws Exception;
+  }
+}
+'''
 
         and:
         assertProjectionCompiles(fixture, 'contract.JavaDeclarationFixture', projection)

--- a/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/SourceProjectionContractTest.groovy
+++ b/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/SourceProjectionContractTest.groovy
@@ -1,0 +1,68 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2024 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.blackbuild.annodocimal.generator
+
+import com.google.testing.compile.Compilation
+import com.google.testing.compile.JavaFileObjects
+import spock.lang.Issue
+
+@Issue("41")
+class SourceProjectionContractTest extends JavaClassGeneratingTest {
+
+    def "supported Java record projections are deterministic and recompilable"() {
+        given:
+        String fixture = 'java-record'
+        compile([
+                'contract.RecordFixture': '''
+                    package contract;
+
+                    import java.io.Serializable;
+
+                    public record RecordFixture<T extends Comparable<? super T>>(T value, String[] aliases)
+                            implements Serializable {
+                        public static class Metadata {}
+                    }
+                '''
+        ], 'contract.RecordFixture')
+        SourceProjector projector = new SourceProjector(ProjectionPolicy.documentation())
+
+        when:
+        String projection = projector.projectToText(file.toPath())
+
+        then:
+        projector.projectToText(file.toPath()) == projection
+
+        and:
+        assertProjectionCompiles(fixture, 'contract.RecordFixture', projection)
+
+        and: 'record kind and component semantics are preserved exactly'
+        projection.contains('public record RecordFixture<T extends Comparable<? super T>>(T value, String[] aliases)')
+    }
+
+    private void assertProjectionCompiles(String fixture, String qualifiedName, String projection) {
+        Compilation result = compiler.compile(JavaFileObjects.forSourceString(qualifiedName, projection))
+        assert result.status() == Compilation.Status.SUCCESS:
+                "Projection fixture '$fixture' failed to compile:\n${result.diagnostics()}\n$projection"
+    }
+}

--- a/docs/source-projection.md
+++ b/docs/source-projection.md
@@ -54,6 +54,10 @@ not promise original bodies or initializers: deterministic default statements an
 requires them for a valid stub. Synthetic implementation details under the documentation preset, original whitespace,
 and import layout are likewise not preserved.
 
+Supported Java records retain their record kind, component list, generic bounds, implemented interfaces, and named
+nested declarations. The projection emits a deterministic canonical-constructor body so both top-level and nested
+record source remains compilable without reconstructing the original constructor implementation.
+
 Generic signatures retain the declaration context needed to resolve every type variable. In particular, a nested member
 type reached through a parameterized enclosing type keeps that owner qualification in method, field, superclass, and
 interface signatures, including inherited signatures with bounds and wildcards. When implementation bytecode retains a

--- a/docs/source-projection.md
+++ b/docs/source-projection.md
@@ -55,8 +55,9 @@ requires them for a valid stub. Synthetic implementation details under the docum
 and import layout are likewise not preserved.
 
 Supported Java records retain their record kind, component list, generic bounds, implemented interfaces, and named
-nested declarations. The projection emits a deterministic canonical-constructor body so both top-level and nested
-record source remains compilable without reconstructing the original constructor implementation.
+nested declarations. When the inclusion policy selects a canonical constructor, the projection emits deterministic
+component assignments; otherwise the record declaration relies on Java's implicit canonical constructor. Both forms
+remain compilable without reconstructing the original constructor implementation.
 
 Generic signatures retain the declaration context needed to resolve every type variable. In particular, a nested member
 type reached through a parameterized enclosing type keeps that owner qualification in method, field, superclass, and


### PR DESCRIPTION
## Summary

- add recompiling Java and Groovy source-projection contract fixtures shared across Groovy 3, 4, and 5
- cover classes, interfaces, annotations, enums, supported records, nested declarations, members, generics, wildcards, arrays, exceptions, and documentation carriers
- preserve declared exceptions for generic signatures and emit valid top-level and nested record projections
- retain exact-output checks plus the existing #32 inherited-generic and #33 annotation-ordering regressions
- document the delivered projection contract and release-facing behavior

## Why

Text-only projection assertions can accept plausible-looking Java that does not compile. The 1.0 contract needs generated projections to be deterministic, documentation-oriented, and valid Java across every supported Groovy generation.

The new matrix recompiles every representative projection and reports the originating fixture when javac rejects it. Building the matrix exposed missing generic-constructor exception metadata and record declarations that were rendered as illegal direct subclasses of `java.lang.Record`.

## Impact

Consumers gain deterministic, recompilable projections for the covered Java and Groovy declaration shapes, including top-level, nested, protected, and package-private records. No method bodies, initializers, original formatting, or KlumAST-specific oracle behavior is introduced.

## Validation

- `./gradlew check`
- focused contract, #32, and #33 tests in Groovy 3, 4, and 5
- `git diff --check`
- parallel Standards and Spec reviews against `6bd0bce`; all findings addressed additively

Closes #41
