### PR TITLE
Apply documentary test and feature-example policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,19 @@ Every newly added test must carry its driving GitHub issue number in Spock's `@I
 sufficient while one issue owns the class, and individual methods identify tests driven by later or different issues.
 Add or amend `@Issue` on changed existing tests only for significant behavioral changes. Apply this rule prospectively;
 do not retrofit unrelated tests.
+Every newly added user-visible feature also needs a readable documentary happy-path test marked with
+`@Tag("documentary")` and linked through `@See` to its canonical documentation under `docs/`. Name new executable test
+classes with the `Test` suffix; use `<Theme>DocumentaryTest` for cohesive dedicated documentary classes, and do not
+blanket-rename existing `*Spec` classes. Keep the feature issue, documentary test, and user documentation mutually
+traceable. See `docs/agents/testing.md`.
+
+### Feature discussion examples
+
+During grilling and implementation, use a compact example as a syntax or API probe for a user-visible feature. Show public
+Java client APIs in Java first and, when meaningful, Groovy second. For Groovy-facing AST authoring or Gradle/plugin
+behavior, use the natural Groovy or Gradle DSL surface. Evolve the accepted example into the documentary test and its
+abbreviated user-documentation example. Internal-only changes may omit the example with a brief reason. See
+`docs/agents/testing.md`.
 
 ### Issue implementation and commits
 

--- a/docs/agents/pull-requests.md
+++ b/docs/agents/pull-requests.md
@@ -21,6 +21,12 @@ or documentation semantics.
   is sufficient while one issue owns the class; use method-level annotations for tests driven by later or different
   issues. Add or amend `@Issue` on changed existing tests only for significant behavioral changes, and do not retrofit
   unrelated tests.
+- Verify that every newly added user-visible feature has a readable documentary happy path marked with
+  `@Tag("documentary")` and linked through `@See` to its canonical documentation under `docs/`, preferably at a stable
+  heading anchor. Confirm that the feature issue, documentary test class and feature method, and documentation section
+  reference one another as defined in `docs/agents/testing.md`.
+- Verify that new executable test classes use the `Test` suffix, normally `<Subject><Concern>Test`, and that dedicated
+  documentary classes use `<Theme>DocumentaryTest`. Do not require unrelated existing `*Spec` classes to be renamed.
 
 ## Review feedback
 
@@ -35,6 +41,8 @@ or documentation semantics.
 - Put detailed user documentation under `docs/`; keep architectural decisions under `docs/adr/`. Do not make a separate
   wiki or generated site the canonical source.
 - Keep published Javadoc, artifact descriptions, plugin metadata, examples, and generated-output terminology consistent.
+- For a newly added user-visible feature, show a concise documentation example aligned with its executable documentary
+  happy path and identify the corresponding documentary test class and feature method.
 - Record user-visible features, fixes, deprecations, and compatibility breaks under the unreleased section of `CHANGES.md`.
 - Put breaking-change migration guides under `docs/migration/` and link them from `CHANGES.md` and the affected user
   documentation. Create the directory lazily when the first migration guide is needed.

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -108,8 +108,8 @@ Keep the feature issue, documentary test, and user documentation mutually tracea
 - The feature issue identifies the documentary test class and feature method, and the relevant documentation section.
 - The documentary test carries the driving `@Issue` number, the `documentary` tag, and an `@See` link to the relevant
   documentation file or section.
-- The documentation shows an abbreviated example aligned with the executable test where practical, and identifies the
-  documentary test class and feature method that exercise it.
+- The documentation shows an abbreviated example aligned with the executable test, and identifies the documentary test
+  class and feature method that exercise it.
 
 This policy applies prospectively. Do not expand unrelated work into a suite-wide documentary-test, naming, or
 traceability audit, and do not rename existing tests merely to conform to the new convention.
@@ -123,5 +123,4 @@ Once accepted, use it as the seed for the documentary happy path and the abbrevi
 - For a public Java client API, show Java first and Groovy second when the Groovy view is meaningful.
 - For Groovy-facing AST authoring, show the natural Groovy source surface.
 - For Gradle or plugin behavior, show the natural Groovy or Gradle DSL surface and omit unrelated build setup.
-- An internal-only change or a discussion without a meaningful usage surface may omit the example, but state the reason
-  briefly rather than skipping it silently.
+- An internal-only change may omit the example, but state the reason briefly rather than skipping it silently.

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -61,3 +61,67 @@ for removing the suppression.
 Published API compatibility is checked against the per-artifact supported-API baseline. The check covers only types
 deliberately classified as supported and must not freeze implementation types merely because they are currently public.
 Any accepted incompatibility needs an intentional release-facing explanation.
+
+## Test class naming and organization
+
+Name every new executable test class with the `Test` suffix. Normally use `<Subject><Concern>Test`, or `<Subject>Test`
+when the subject is already narrow. Do not introduce new `*Spec` names, and do not expand unrelated work into a blanket
+rename of existing `*Spec` classes.
+
+A production class or concept does not require a one-to-one test class. Split tests when each resulting class has a
+cohesive purpose and the split improves readability, navigation, or fixture clarity; keep related behavior together when
+splitting would fragment ownership or duplicate setup.
+
+## Documentary tests
+
+Every newly added user-visible feature must have one or more readable documentary tests. At least one should be a happy
+path that demonstrates the feature's basic use as executable code. Prefer meaningful API or plugin examples over
+placeholder names when that makes the intended use easier to understand.
+
+Mark each documentary Spock test with `@Tag("documentary")`. Put the tag on the feature method unless the whole class is
+documentary, in which case a class-level tag is sufficient. Put `@See` on the same feature or class and link it to the
+relevant canonical AnnoDocimal documentation under `docs/`, preferably to a stable heading anchor. Because Spock exposes
+`@See` as a report attachment, use an absolute URL to the repository documentation.
+
+Documentary examples may stay beside focused behavioral tests or live in a dedicated thematic class. Prefer a cohesive
+`<Theme>DocumentaryTest` when several examples form a useful reading path, share understandable setup, or span multiple
+driving issues within one theme. Keep an isolated happy path with its focused behavioral tests when extraction would
+duplicate fixtures or fragment ownership. Use `DocumentaryTest`, not `DocumentationTest`, for a dedicated class.
+
+Put `@Tag("documentary")` on a dedicated documentary class. If its feature methods originate from different issues, put
+`@Issue` on each method. Put `@See` on each method when documentation targets differ; a class-level `@See` is sufficient
+only when one documentation target genuinely covers the whole class.
+
+A typical documentary feature method looks like:
+
+```groovy
+@Issue("123")
+@Tag("documentary")
+@See("https://github.com/blackbuild/anno-docimal/blob/master/docs/usage.md#capture-documentation")
+def "demonstrates the basic feature usage"() {
+    // readable happy path
+}
+```
+
+Keep the feature issue, documentary test, and user documentation mutually traceable:
+
+- The feature issue identifies the documentary test class and feature method, and the relevant documentation section.
+- The documentary test carries the driving `@Issue` number, the `documentary` tag, and an `@See` link to the relevant
+  documentation file or section.
+- The documentation shows an abbreviated example aligned with the executable test where practical, and identifies the
+  documentary test class and feature method that exercise it.
+
+This policy applies prospectively. Do not expand unrelated work into a suite-wide documentary-test, naming, or
+traceability audit, and do not rename existing tests merely to conform to the new convention.
+
+## Feature discussion examples
+
+During grilling and implementation of a user-visible feature, use a compact example as a syntax or API probe before the
+design is settled. Keep it small enough to expose awkward calls, names, or configuration and to compare alternatives.
+Once accepted, use it as the seed for the documentary happy path and the abbreviated documentation example.
+
+- For a public Java client API, show Java first and Groovy second when the Groovy view is meaningful.
+- For Groovy-facing AST authoring, show the natural Groovy source surface.
+- For Gradle or plugin behavior, show the natural Groovy or Gradle DSL surface and omit unrelated build setup.
+- An internal-only change or a discussion without a meaningful usage surface may omit the example, but state the reason
+  briefly rather than skipping it silently.


### PR DESCRIPTION
## Summary

- require a readable documentary happy-path test for every newly added user-visible feature, with Spock `@Tag("documentary")`, `@See` links to canonical `docs/` content, and reciprocal issue/test/documentation traceability
- establish prospective `Test` and `<Theme>DocumentaryTest` naming without retrofitting existing `*Spec` classes
- add compact feature-discussion examples and matching pull-request checklist guidance for AnnoDocimal's Java API, Groovy AST, and Gradle/plugin surfaces

## Why

This adapts the documentary-test and feature-example policy established by [KlumAST PR #493](https://github.com/klum-dsl/klum-ast/pull/493) to AnnoDocimal's library/API/plugin context. It retains AnnoDocimal's repository-owned `docs/` location, terminology, Java 17 and Groovy 3–5 compatibility lanes, prospective `@Issue` policy, and documentation-only validation exemption.

## Impact

Policy-only and prospective. No production code, tests, existing test names, issues, labels, milestones, or release behavior change.

## Validation

- `git diff --check origin/master...HEAD`
- focused standards/spec review; standards passed and both wording findings were resolved additively in `21431f6`
- no repository Markdown or link checker is configured
- Gradle intentionally omitted because these Markdown-only policy edits cannot affect compilation, test execution, generated output, or runtime behavior