### PR TITLE
Provision a supported SonarCloud analysis JRE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,12 @@ jobs:
           restore-keys: ${{ runner.os }}-sonar
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
-      - name: Build with Gradle
+      - name: Verify Gradle JVM is Java 17
+        run: ./gradlew --version
+      - name: Build and produce coverage with Java 17
+        run: ./gradlew build jacocoTestReport
+      - name: Analyze with auto-provisioned Sonar JRE
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run:
-          ./gradlew build jacocoTestReport sonar
+        run: ./gradlew sonar --info

--- a/docs/implementation/architecture-and-agent-baseline.md
+++ b/docs/implementation/architecture-and-agent-baseline.md
@@ -549,7 +549,8 @@ wiring currently belong to the consumer.
 - Java toolchains target 17.
 - Groovy 3.0.25 is the baseline test runtime; Groovy 4.0.32 and 5.0.6 use compatibility suites over shared tests.
 - `./gradlew check` passed on 2026-07-16 and exercised all configured Groovy lanes.
-- CI uses one Ubuntu/JDK 17 job and runs `build jacocoTestReport sonar`; the Gradle graph supplies compatibility lanes.
+- CI uses one Ubuntu/JDK 17 job. A Java 17 Gradle invocation runs `build jacocoTestReport`, followed by `sonar --info`
+  with SonarScanner's auto-provisioned analysis JRE; the Gradle graph supplies compatibility lanes.
 - Six artifacts and two Gradle plugin markers are configured for publication through Maven Central/Plugin Portal tooling.
 - Most artifacts publish Gradle module metadata; the generator shadow publication does not.
 - The five Java-facing module-path artifacts declare the stable automatic names confirmed for issue #36; the Gradle

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,7 +7,7 @@ pluginManagement {
         id "com.github.ben-manes.versions" version "0.51.0"
         id "io.github.gradle-nexus.publish-plugin" version "1.3.0"
         id 'com.gradle.plugin-publish' version '1.2.1'
-        id "org.sonarqube" version "5.0.0.4638"
+        id "org.sonarqube" version "6.2.0.5505"
     }
     repositories {
         mavenCentral()


### PR DESCRIPTION
## Summary

- upgrade SonarScanner for Gradle from 5.0.0.4638 to 6.2.0.5505
- keep Gradle, compilation, Groovy compatibility lanes, tests, and JaCoCo production on JDK 17
- run `build jacocoTestReport` before a separate verbose `sonar` invocation so CI exposes producer ordering and the auto-provisioned analysis runtime
- record the resulting CI runtime split in the implementation baseline

## Root cause

SonarQube Cloud no longer accepts Java 17 as the scanner engine runtime. The existing SonarScanner for Gradle 5.0.0 ran analysis inside the Java 17 Gradle process, so PR #74 completed its behavioral build and coverage production and then failed at `:sonar`.

SonarScanner for Gradle 6.2.0.5505 supports default JRE auto-provisioning. This leaves AnnoDocimal's Java 17 product and CI baseline unchanged while allowing SonarQube Cloud to provision its supported analysis JRE.

## Compatibility impact

No product, source/target, toolchain, Gradle, Groovy, artifact metadata, or credential baseline changes. `sonar.gradle.skipCompile=true` remains enabled, and issue #46 remains open for the broader CI evidence matrix.

## Validation

- Gradle 8.14.5 launcher and daemon verified on Java 17
- SonarScanner 6.2.0.5505 configuration and compile-independent `sonar` task dry-run on Java 17
- `./gradlew check`
- `./gradlew build jacocoTestReport`
- five module JaCoCo XML reports verified locally
- workflow YAML parsing and `git diff --check origin/master...HEAD`
- two-axis Standards and Spec review: no findings

## CI proof required before merge

The CI log must show:

- the Gradle JVM remains Java 17
- compiled classes and all JaCoCo XML reports precede analysis
- the provisioned scanner engine uses Java 21 or later
- JaCoCo XML is discovered and imported
- SonarQube Cloud analysis succeeds

Related: #46
