### PR TITLE
Audit AnnoDocimal 1.0 adopter documentation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,7 +43,8 @@
 
 - Rewrote the repository-owned landing page, usage guide, and migration guidance for the 1.0 documentation contract.
   They now describe the six artifacts, Java and Groovy capture, the supported authoring and projection APIs, automatic
-  module names, Javadoc and IDE-mirror boundaries, and the current versus #35-owned Gradle integration. See
+  module names, Javadoc and IDE-mirror boundaries, and the conventional and independently configurable Gradle
+  integrations. See
   [the usage guide](docs/user/usage.md) and [0.x-to-1.0 migration](docs/user/migration/0.x-to-1.0-supported-api.md).
 
 - Defined the supported 1.0 Java API as non-null by default with JSpecify. Supported annotation, transformation-author,

--- a/docs/implementation/1.0-adopter-documentation-audit.md
+++ b/docs/implementation/1.0-adopter-documentation-audit.md
@@ -1,0 +1,50 @@
+# AnnoDocimal 1.0 adopter-documentation audit
+
+Audit date: 2026-07-22. This local audit examines repository-authored adopter content through the current pre-1.0
+state. It does not decide product, release, or static-site presentation policy.
+
+## Scope and evidence
+
+The audited journey starts at [the user landing page](../user/Home.md), selects capture and artifacts in
+[the usage guide](../user/usage.md), adopts the supported transformation-author facade and value model, then moves to
+source projection and the 0.x migration guides. The resulting journey is coherent and source-backed:
+
+- `AstDocumentation` supplies exact extraction, semantic/text attachment, and references; `Documentation` provides the
+  immutable value model and explicit templates. Their contract is recorded by ADRs 0053, 0057, 0058, and 0059 and is
+  exercised by `AstDocumentationTest` and `DocumentationTest`.
+- Capture guidance distinguishes the canonical AnnoDocimal protocol from runtime GroovyDoc as an interoperable carrier,
+  as required by ADRs 0020, 0023, and 0024. The cross-Groovy capture and projection paths are covered by the issue #19
+  and #43 test suites.
+- The source-projection guide matches `SourceProjector`, `ProjectionPolicy`, and `SourceProjectionTask`, including the
+  distinction between Javadoc convenience output and an IDE-only mirror. Its consumer migration remains explicitly
+  assigned to KlumAST #461 rather than claimed as AnnoDocimal delivery.
+- The documentation history from tag `v0.7.1` through commits `2279fa3`, `27f38ce`, `af67151`, `70098c2`, `cd98c45`,
+  `c445535`, and `3b091c0` records the 1.0 authoring, projection, capture, Gradle, and navigation material. The
+  `Unreleased` history records those delivered changes; historical release-note backfill correctly remains
+  evidence-based under ADR 0016.
+
+## Corrected findings
+
+- The supported-API record incorrectly said that the public
+  `InlineJavadocs.JAVADOC_PROPERTIES_SUFFIX` field would be removed or hidden. The annotation still declares the field,
+  and APT/extraction use it internally. The user and migration guidance now state that it remains public but unsupported;
+  adopters must use the documented `__annodoc.properties` protocol instead.
+- The same record described completed ADR 0058 authoring corrections and issue #35's delivered Gradle task in the
+  future/present tense. The user-facing wording now reflects the completed supported API and task contract.
+- The projection guide no longer describes `SourceProjectionTask` collection behavior as future issue #35 work.
+
+## Deferred gaps and ownership
+
+- **Groovy property documentation:** issue #9 remains the owner of the semantic property/backing-field/accessor mapping
+  required by ADR 0033. The current docs must not invent that mapping. Once #9 establishes it, its owner should add the
+  user-facing rule, a Groovy-native example, and cross-Groovy documentary evidence.
+- **Consumer adoption:** KlumAST #461 owns the downstream migration. AnnoDocimal documentation can describe the mapping,
+  but must not state that the consumer has adopted it. The KlumAST owner should publish its adoption evidence there.
+- **Documentary examples:** focused authoring tests predate the prospective `@Tag("documentary")`/`@See` policy, so this
+  audit does not retrofit them. The owner of the next new adopter-facing feature should add a tagged documentary happy
+  path linked to its canonical user documentation, or explicitly record why it does not apply.
+
+## Boundary
+
+This note concerns canonical adopter documentation only. Versioned-site rendering, Pages presentation, release
+workflow, publication validation, and release recovery remain outside this audit.

--- a/docs/implementation/1.0-adopter-documentation-audit.md
+++ b/docs/implementation/1.0-adopter-documentation-audit.md
@@ -29,8 +29,8 @@ source projection and the 0.x migration guides. The resulting journey is coheren
   `InlineJavadocs.JAVADOC_PROPERTIES_SUFFIX` field would be removed or hidden. The annotation still declares the field,
   and APT/extraction use it internally. The user and migration guidance now state that it remains public but unsupported;
   adopters must use the documented `__annodoc.properties` protocol instead.
-- The same record described completed ADR 0058 authoring corrections and issue #35's delivered Gradle task in the
-  future/present tense. The user-facing wording now reflects the completed supported API and task contract.
+- The same record described completed ADR 0058 authoring corrections and the implemented Gradle task in the
+  future/present tense. The user-facing wording now reflects the current supported API and task contract.
 - The projection guide no longer describes `SourceProjectionTask` collection behavior as future issue #35 work.
 
 ## Deferred gaps and ownership
@@ -43,6 +43,10 @@ source projection and the 0.x migration guides. The resulting journey is coheren
 - **Documentary examples:** focused authoring tests predate the prospective `@Tag("documentary")`/`@See` policy, so this
   audit does not retrofit them. The owner of the next new adopter-facing feature should add a tagged documentary happy
   path linked to its canonical user documentation, or explicitly record why it does not apply.
+- **Release-plan status:** the issue #35 source, tests, merged history, and closed issue support the implemented
+  `SourceProjectionTask` capability, but the older 1.0 implementation plans still list #35 as unfinished. This audit
+  does not decide the gate's release status. The release-plan maintainer should reconcile that tracker narrative with
+  the current issue evidence and record any remaining release evidence separately.
 
 ## Boundary
 

--- a/docs/user/migration/0.x-to-1.0-supported-api.md
+++ b/docs/user/migration/0.x-to-1.0-supported-api.md
@@ -30,7 +30,7 @@ language-injection metadata and are unrelated to API nullability.
 | `DocText` parsing, inspection, or tag replacement | `Documentation.parse`, value accessors, and `toBuilder()` |
 | `DocBuilder` / `JavadocDocBuilder` | `Documentation.Builder` and `Documentation.render()` |
 | `JavaDocUtil.toLinkString` | `AstDocumentation.referenceTo` |
-| `InlineJavadocs.JAVADOC_PROPERTIES_SUFFIX` | No supported Java constant. Rely on the documented `__annodoc.properties` protocol resource and its class, method, and field key semantics instead. |
+| `InlineJavadocs.JAVADOC_PROPERTIES_SUFFIX` | The public field remains unsupported implementation compatibility. Rely on the documented `__annodoc.properties` protocol resource and its class, method, and field key semantics instead. |
 | Direct metadata constants, source extractors, visitors, or Groovy-version handlers | No replacement; consume the facade's supported behavior |
 
 `extractExact` never performs inherited lookup. Do not replace an old fallback overload with implicit hierarchy traversal;

--- a/docs/user/source-projection.md
+++ b/docs/user/source-projection.md
@@ -91,4 +91,5 @@ to the generator shadow JAR so module-path consumers do not receive a duplicate 
 
 The provisional 0.x `AnnoDocGenerator` helper is removed without a compatibility shim. See the
 [0.x-to-1.0 supported-API migration](migration/0.x-to-1.0-supported-api.md) for the direct replacement. The reusable
-Gradle task contract, including collection filtering and stale-output cleanup, remains owned by issue #35.
+`SourceProjectionTask` handles collection filtering and stale-output cleanup; its supported Gradle contract is described
+in the [usage guide](usage.md#source-projection-javadoc-and-ide-mirrors).

--- a/docs/user/supported-api.md
+++ b/docs/user/supported-api.md
@@ -17,8 +17,8 @@ Classification terms are:
   consumer API; and
 - **provisional**: must receive its stated disposition before the 1.0 baseline is locked.
 
-No public type remains provisional after the issue #37 and #51 decisions. The merged authoring implementation still has
-the pre-baseline member corrections in ADR 0058; those do not make its seven selected types provisional.
+No public type remains provisional after the issue #37 and #51 decisions. The authoring implementation incorporated the
+pre-baseline member corrections in ADR 0058 before its scoped allowlist was delivered.
 
 ## Nullability contract
 
@@ -52,8 +52,9 @@ Supported Java types and members:
   triggers local capture.
 
 The externally observable `__annodoc.properties` resource suffix and the class, method, and field key semantics
-are supported data-protocol behavior. `InlineJavadocs.JAVADOC_PROPERTIES_SUFFIX` is not supported Java API and is removed
-or hidden in 1.0; no new public properties utility is introduced merely to expose that constant.
+are supported data-protocol behavior. `InlineJavadocs.JAVADOC_PROPERTIES_SUFFIX` remains a public implementation
+compatibility field, but is not supported Java API; consumers must rely on the documented protocol rather than that
+constant. No new public properties utility is introduced merely to expose it.
 
 ### `anno-docimal-apt`
 
@@ -147,7 +148,7 @@ applies Gradle's Groovy plugin and the base layer. Plugin implementation classes
 | Current public type | Classification | 1.0 disposition |
 |---|---|---|
 | `com.blackbuild.annodocimal.annotations.AnnoDoc` | supported | Retain the annotation and `value()` carrier contract. |
-| `com.blackbuild.annodocimal.annotations.InlineJavadocs` | supported | Retain the marker; remove or hide its public suffix constant. |
+| `com.blackbuild.annodocimal.annotations.InlineJavadocs` | supported | Retain the marker; leave its public suffix constant unsupported. |
 
 ### APT artifact
 
@@ -330,5 +331,5 @@ output, plugin-ID behavior, and JPMS module names are not reduced to JVM signatu
 
 Issue #51 resolved the former builder slot and introduced a scoped authoring baseline. Issue #38 applied ADR 0058's
 pre-1.0 corrections, issue #39 added the scoped projection baseline, and issue #59 made their nullability annotations
-compatibility evidence. Issue #35 adds the Gradle type. Release compatibility work then generates and verifies complete
+compatibility evidence. Issue #35 added the Gradle type. Release compatibility work then generates and verifies complete
 per-artifact snapshots from this record rather than from the 0.x public surface or from all public bytecode.

--- a/docs/user/supported-api.md
+++ b/docs/user/supported-api.md
@@ -2,8 +2,8 @@
 
 This record is the human-authoritative classification produced by issue #37. Java `public` visibility, inclusion in a
 published JAR, a service-provider name, or relocation into the generator artifact does not by itself make a type
-supported. Issues #35, #38, and #39 have delivered their scoped allowlists. Release compatibility work generates the
-complete mechanical snapshots from those classifications.
+supported. The scoped allowlists for issues #35, #38, and #39 are recorded here. Release compatibility work generates
+the complete mechanical snapshots from those classifications.
 
 The inventory began with all six artifacts at commit `981a511` and was refreshed through `505a4ae`, after the issue #51
 authoring implementation merged. It contains all 120 public top-level and nested types in those JARs: the original 113,
@@ -331,5 +331,6 @@ output, plugin-ID behavior, and JPMS module names are not reduced to JVM signatu
 
 Issue #51 resolved the former builder slot and introduced a scoped authoring baseline. Issue #38 applied ADR 0058's
 pre-1.0 corrections, issue #39 added the scoped projection baseline, and issue #59 made their nullability annotations
-compatibility evidence. Issue #35 added the Gradle type. Release compatibility work then generates and verifies complete
-per-artifact snapshots from this record rather than from the 0.x public surface or from all public bytecode.
+compatibility evidence. The scoped baseline includes the Gradle type. Release compatibility work then generates and
+verifies complete per-artifact snapshots from this record rather than from the 0.x public surface or from all public
+bytecode.


### PR DESCRIPTION
## Summary

- Adds a source-backed audit of the 1.0 adopter journey and its remaining ownership boundaries.
- Corrects stale supported-API, migration, projection, and changelog wording.
- Records the unresolved property-documentation, downstream-adoption, documentary-evidence, and #35 release-plan-status follow-ups without deciding product or release policy.

## Why

The public documentation-properties suffix field remains unsupported API, and several user-facing references still described completed authoring and Gradle work as future work.

## Impact

Adopters receive accurate guidance for the public-but-unsupported suffix field and the current source-projection task. The audit keeps consumer adoption and release-plan reconciliation with their respective owners.

## Validation

- `git diff --check origin/master...HEAD`
- Changed Markdown relative links and heading anchors
- Two-axis standards/spec review; one spec finding was addressed in follow-up commit d0763b2

Gradle checks were not run because this is documentation-only and does not affect compilation, generated output, or runtime behavior.