### PR TITLE
Capture Groovy property documentation semantics

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Groovy property documentation is now retained as property semantics across capture and source projection. The
+  normalized textual carrier stays on the backing field, undocumented custom accessors inherit it, and projected
+  Groovy-generated getters and setters receive it while explicitly documented accessors keep precedence. Projection does
+  not apply general JavaBeans inference; see the [usage guide](docs/user/usage.md#groovy-property-documentation) and
+  [authoring migration](docs/user/migration/0.x-to-1.0-authoring-language.md#groovy-property-documentation).
+
 - Added a protected, immutable GitHub Pages publication seam for deterministic static HTML and all supported Java API
   Javadocs. Pull requests render and crawl a distinct non-release rehearsal without deployment; exact release manifests
   cover the deployed HTML, assets, and Javadoc bytes. Release authorization and recovery remain in the #45 runbook. See

--- a/README.md
+++ b/README.md
@@ -3,5 +3,8 @@
 AnnoDocimal preserves documentation for generated JVM APIs through compilation and reconstructs documentation-oriented
 Java source for Javadoc and IDE source mirrors.
 
+Groovy property documentation remains associated with its backing field and accessors through capture and source
+projection; see the [property documentation policy](docs/user/usage.md#groovy-property-documentation).
+
 - [User documentation](docs/user/Home.md)
 - [Change history](CHANGES.md)

--- a/anno-docimal-annotations/src/main/java/com/blackbuild/annodocimal/annotations/GroovyPropertyDocumentation.java
+++ b/anno-docimal-annotations/src/main/java/com/blackbuild/annodocimal/annotations/GroovyPropertyDocumentation.java
@@ -1,0 +1,55 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2024 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.blackbuild.annodocimal.annotations;
+
+import org.jspecify.annotations.NullMarked;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Classfile metadata associating a captured Groovy property backing field with its accessor methods.
+ *
+ * <p>The metadata contains no documentation content. {@link AnnoDoc} remains the textual documentation carrier.</p>
+ */
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.CLASS)
+@NullMarked
+public @interface GroovyPropertyDocumentation {
+    /**
+     * Names of getter methods belonging to the property.
+     *
+     * @return accessor names
+     */
+    String[] getters();
+
+    /**
+     * Names of setter methods belonging to the property.
+     *
+     * @return accessor names
+     */
+    String[] setters();
+}

--- a/anno-docimal-ast/src/main/java/com/blackbuild/annodocimal/ast/InlineJavadocsVisitor.java
+++ b/anno-docimal-ast/src/main/java/com/blackbuild/annodocimal/ast/InlineJavadocsVisitor.java
@@ -29,15 +29,23 @@ import com.blackbuild.annodocimal.ast.parser.SourceExtractorFactory;
 import org.codehaus.groovy.ast.*;
 import org.codehaus.groovy.control.SourceUnit;
 
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 
 /**
  * AST visitor that inlines Javadoc comments as annotations.
+ *
+ * <p>For Groovy properties, the visitor preserves property documentation on the backing field and copies it to an
+ * undocumented custom accessor. Generated accessor documentation is associated during source projection, where Groovy's
+ * generated-member metadata remains available.</p>
  */
 public class InlineJavadocsVisitor extends ClassCodeVisitorSupport {
     private final SourceUnit sourceUnit;
 
     private final SourceExtractor sourceExtractor;
+
+    private final List<PropertyDocumentation> propertyDocumentation = new ArrayList<>();
 
     public InlineJavadocsVisitor(SourceUnit sourceUnit) {
         this.sourceUnit = sourceUnit;
@@ -53,6 +61,7 @@ public class InlineJavadocsVisitor extends ClassCodeVisitorSupport {
     public void visitClass(ClassNode node) {
         addJavadocAsAnnotation(node);
         node.visitContents(this);
+        applyPropertyDocumentation();
         for (Iterator<InnerClassNode> it = node.getInnerClasses(); it.hasNext(); ) {
             InnerClassNode innerClassNode = it.next();
             visitClass(innerClassNode);
@@ -71,7 +80,44 @@ public class InlineJavadocsVisitor extends ClassCodeVisitorSupport {
 
     @Override
     public void visitProperty(PropertyNode node) {
-        // properties have no annotations
+        FieldNode field = node.getField();
+        String documentation = sourceExtractor.getJavaDoc(node);
+        if ((documentation == null || documentation.isBlank()) && field != null)
+            documentation = sourceExtractor.getJavaDoc(field);
+        if (documentation != null && !documentation.isBlank()) {
+            propertyDocumentation.add(new PropertyDocumentation(node, documentation));
+        }
+    }
+
+    private void applyPropertyDocumentation() {
+        for (PropertyDocumentation property : propertyDocumentation) {
+            addDocumentationIfAbsent(property.node().getField(), property.documentation());
+
+            ClassNode owner = property.node().getField().getOwner();
+            String propertyName = capitalize(property.node().getName());
+            MethodNode getter = owner.getGetterMethod("get" + propertyName, false);
+            if (getter == null && isBoolean(property.node()))
+                getter = owner.getGetterMethod("is" + propertyName, false);
+            addDocumentationIfAbsent(getter, property.documentation());
+
+            MethodNode setter = owner.getSetterMethod("set" + propertyName, false);
+            addDocumentationIfAbsent(setter, property.documentation());
+        }
+        propertyDocumentation.clear();
+    }
+
+    private static boolean isBoolean(PropertyNode property) {
+        return ClassHelper.boolean_TYPE.equals(property.getType()) || ClassHelper.Boolean_TYPE.equals(property.getType());
+    }
+
+    private static String capitalize(String name) {
+        if (name.isEmpty()) return name;
+        return Character.toUpperCase(name.charAt(0)) + name.substring(1);
+    }
+
+    private static void addDocumentationIfAbsent(AnnotatedNode node, String documentation) {
+        if (node == null || AnnoDocUtil.getDocumentationCarrierValue(node) != null) return;
+        AnnoDocUtil.addDocumentation(node, documentation);
     }
 
     private void addJavadocAsAnnotation(AnnotatedNode node) {
@@ -82,5 +128,7 @@ public class InlineJavadocsVisitor extends ClassCodeVisitorSupport {
         if (javadoc != null && !javadoc.isBlank())
             AnnoDocUtil.addDocumentation(node, javadoc);
     }
+
+    private record PropertyDocumentation(PropertyNode node, String documentation) {}
 
 }

--- a/anno-docimal-ast/src/main/java/com/blackbuild/annodocimal/ast/InlineJavadocsVisitor.java
+++ b/anno-docimal-ast/src/main/java/com/blackbuild/annodocimal/ast/InlineJavadocsVisitor.java
@@ -26,7 +26,11 @@ package com.blackbuild.annodocimal.ast;
 import com.blackbuild.annodocimal.ast.formatting.AnnoDocUtil;
 import com.blackbuild.annodocimal.ast.parser.SourceExtractor;
 import com.blackbuild.annodocimal.ast.parser.SourceExtractorFactory;
+import com.blackbuild.annodocimal.annotations.GroovyPropertyDocumentation;
 import org.codehaus.groovy.ast.*;
+import org.codehaus.groovy.ast.expr.ConstantExpression;
+import org.codehaus.groovy.ast.expr.Expression;
+import org.codehaus.groovy.ast.expr.ListExpression;
 import org.codehaus.groovy.control.SourceUnit;
 
 import java.util.ArrayList;
@@ -91,19 +95,42 @@ public class InlineJavadocsVisitor extends ClassCodeVisitorSupport {
 
     private void applyPropertyDocumentation() {
         for (PropertyDocumentation property : propertyDocumentation) {
-            addDocumentationIfAbsent(property.node().getField(), property.documentation());
+            FieldNode field = property.node().getField();
+            if (field == null) continue;
+            addDocumentationIfAbsent(field, property.documentation());
+            addPropertyMapping(field, property.node());
 
-            ClassNode owner = property.node().getField().getOwner();
+            ClassNode owner = field.getOwner();
             String propertyName = capitalize(property.node().getName());
             MethodNode getter = owner.getGetterMethod("get" + propertyName, false);
-            if (getter == null && isBoolean(property.node()))
-                getter = owner.getGetterMethod("is" + propertyName, false);
             addDocumentationIfAbsent(getter, property.documentation());
+            if (isBoolean(property.node())) {
+                MethodNode booleanGetter = owner.getGetterMethod("is" + propertyName, false);
+                addDocumentationIfAbsent(booleanGetter, property.documentation());
+            }
 
             MethodNode setter = owner.getSetterMethod("set" + propertyName, false);
             addDocumentationIfAbsent(setter, property.documentation());
         }
         propertyDocumentation.clear();
+    }
+
+    private static void addPropertyMapping(FieldNode field, PropertyNode property) {
+        if (!field.getAnnotations(ClassHelper.make(GroovyPropertyDocumentation.class)).isEmpty()) return;
+
+        String propertyName = capitalize(property.getName());
+        List<String> getters = new ArrayList<>();
+        getters.add("get" + propertyName);
+        if (isBoolean(property)) getters.add("is" + propertyName);
+
+        AnnotationNode mapping = new AnnotationNode(ClassHelper.make(GroovyPropertyDocumentation.class));
+        mapping.addMember("getters", strings(getters));
+        mapping.addMember("setters", strings(List.of("set" + propertyName)));
+        field.addAnnotation(mapping);
+    }
+
+    private static ListExpression strings(List<String> values) {
+        return new ListExpression(values.stream().<Expression>map(ConstantExpression::new).toList());
     }
 
     private static boolean isBoolean(PropertyNode property) {

--- a/anno-docimal-ast/src/test/groovy/com/blackbuild/annodocimal/ast/GroovyPropertyDocumentationDocumentaryTest.groovy
+++ b/anno-docimal-ast/src/test/groovy/com/blackbuild/annodocimal/ast/GroovyPropertyDocumentationDocumentaryTest.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2026 Stephan Pauxberger
+ * Copyright (c) 2024 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-ast/src/test/groovy/com/blackbuild/annodocimal/ast/GroovyPropertyDocumentationDocumentaryTest.groovy
+++ b/anno-docimal-ast/src/test/groovy/com/blackbuild/annodocimal/ast/GroovyPropertyDocumentationDocumentaryTest.groovy
@@ -1,0 +1,64 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2026 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.blackbuild.annodocimal.ast
+
+import com.blackbuild.annodocimal.annotations.AnnoDoc
+import spock.lang.Issue
+import spock.lang.See
+import spock.lang.Tag
+
+@Issue('9')
+@Tag('documentary')
+@See('https://github.com/blackbuild/anno-docimal/blob/master/docs/user/usage.md#groovy-property-documentation')
+class GroovyPropertyDocumentationDocumentaryTest extends ClassGeneratingSpecification {
+
+    def 'captures property documentation and respects explicit accessor documentation'() {
+        when:
+        createClass('''
+            package dummy
+
+            import com.blackbuild.annodocimal.annotations.InlineJavadocs
+
+            @InlineJavadocs
+            class DocumentedProperties {
+                /** A title callers can read and write. */
+                String title
+
+                /** A service endpoint. */
+                String endpoint
+
+                /** Returns the normalized endpoint. */
+                String getEndpoint() { endpoint }
+
+                void setEndpoint(String endpoint) { this.endpoint = endpoint }
+            }
+        ''')
+
+        then:
+        clazz.getDeclaredField('title').getAnnotation(AnnoDoc).value() == 'A title callers can read and write.'
+        clazz.getDeclaredField('endpoint').getAnnotation(AnnoDoc).value() == 'A service endpoint.'
+        clazz.getMethod('getEndpoint').getAnnotation(AnnoDoc).value() == 'Returns the normalized endpoint.'
+        clazz.getMethod('setEndpoint', String).getAnnotation(AnnoDoc).value() == 'A service endpoint.'
+    }
+}

--- a/anno-docimal-ast/src/test/groovy/com/blackbuild/annodocimal/ast/InlineJavadocsTransformationTest.groovy
+++ b/anno-docimal-ast/src/test/groovy/com/blackbuild/annodocimal/ast/InlineJavadocsTransformationTest.groovy
@@ -319,6 +319,17 @@ class PropertyDocumentation {
     /** Property documentation. */
     String title
 
+    /** Custom boolean property. */
+    boolean ready
+
+    /** Explicit boolean getter documentation. */
+    boolean isReady() { ready }
+
+    /** Undocumented custom boolean accessor property. */
+    boolean available
+
+    boolean isAvailable() { available }
+
     /** Explicit getter documentation. */
     String getTitle() { title }
 
@@ -328,6 +339,8 @@ class PropertyDocumentation {
 
         then:
         clazz.getDeclaredField('title').getAnnotation(AnnoDoc).value() == 'Property documentation.'
+        clazz.getMethod('isReady').getAnnotation(AnnoDoc).value() == 'Explicit boolean getter documentation.'
+        clazz.getMethod('isAvailable').getAnnotation(AnnoDoc).value() == 'Undocumented custom boolean accessor property.'
         clazz.getMethod('getTitle').getAnnotation(AnnoDoc).value() == 'Explicit getter documentation.'
         clazz.getMethod('setTitle', String).getAnnotation(AnnoDoc).value() == 'Property documentation.'
     }

--- a/anno-docimal-ast/src/test/groovy/com/blackbuild/annodocimal/ast/InlineJavadocsTransformationTest.groovy
+++ b/anno-docimal-ast/src/test/groovy/com/blackbuild/annodocimal/ast/InlineJavadocsTransformationTest.groovy
@@ -305,4 +305,30 @@ class TestClass {
         then:
         noExceptionThrown()
     }
+
+    @Issue("9")
+    def "property documentation is captured on the backing field and undocumented custom accessors"() {
+        when:
+        createClass "dummy/PropertyDocumentation.groovy", '''
+package dummy
+
+import com.blackbuild.annodocimal.annotations.InlineJavadocs
+
+@InlineJavadocs
+class PropertyDocumentation {
+    /** Property documentation. */
+    String title
+
+    /** Explicit getter documentation. */
+    String getTitle() { title }
+
+    void setTitle(String title) { this.title = title }
+}
+'''
+
+        then:
+        clazz.getDeclaredField('title').getAnnotation(AnnoDoc).value() == 'Property documentation.'
+        clazz.getMethod('getTitle').getAnnotation(AnnoDoc).value() == 'Explicit getter documentation.'
+        clazz.getMethod('setTitle', String).getAnnotation(AnnoDoc).value() == 'Property documentation.'
+    }
 }

--- a/anno-docimal-generator/build.gradle
+++ b/anno-docimal-generator/build.gradle
@@ -19,6 +19,7 @@ dependencies {
     implementation "org.ow2.asm:asm-tree:9.10.1"
     sharedTests "com.google.testing.compile:compile-testing:0.23.0"
     sharedTests project(':anno-docimal-annotations')
+    sharedTests project(':anno-docimal-ast')
     sharedTests "com.squareup:javapoet:1.13.0"
 }
 

--- a/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/JavaPoetClassVisitor.java
+++ b/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/JavaPoetClassVisitor.java
@@ -30,7 +30,6 @@ import org.objectweb.asm.signature.SignatureReader;
 import org.objectweb.asm.signature.SignatureVisitor;
 
 import javax.lang.model.element.Modifier;
-import java.beans.Introspector;
 import java.io.IOException;
 import java.util.*;
 import java.util.function.Consumer;
@@ -43,6 +42,8 @@ import static java.util.stream.Collectors.toSet;
 
 class JavaPoetClassVisitor extends ClassVisitor {
     static final String ANNO_DOC_CLASS = "com.blackbuild.annodocimal.annotations.AnnoDoc";
+    static final String GROOVY_PROPERTY_DOCUMENTATION_CLASS =
+            "com.blackbuild.annodocimal.annotations.GroovyPropertyDocumentation";
     static final String GROOVYDOC_CLASS = "groovy.lang.Groovydoc";
     private static final String CONSTRUCTOR_NAME = "<init>";
     private final SpecConverter specConverter;
@@ -62,7 +63,7 @@ class JavaPoetClassVisitor extends ClassVisitor {
     private boolean recordDeclaration;
     private final List<RecordComponentShape> recordComponents = new ArrayList<>();
     private final List<RecordShape> recordShapes = new ArrayList<>();
-    private final Map<String, String> groovyPropertyDocumentation = new HashMap<>();
+    private final Map<String, GroovyPropertyMapping> groovyPropertyMappings = new LinkedHashMap<>();
 
     JavaPoetClassVisitor(SpecConverter specConverter, ProjectionPolicy policy, Set<String> includedClasses,
                          boolean groovyClass, Set<String> groovyRuntimeMethods, Set<String> groovyRuntimeFields) {
@@ -298,14 +299,10 @@ class JavaPoetClassVisitor extends ClassVisitor {
             final MemberAnnotationVisitor.DocumentationCarrierSelection documentation =
                     new MemberAnnotationVisitor.DocumentationCarrierSelection();
             int visitedParameters;
-            boolean generated;
 
             @Override
             public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
                 Type annotationType = Type.getType(desc);
-                if (annotationType.getClassName().equals("groovy.transform.Generated")) {
-                    generated = true;
-                }
                 if (annotationType.getClassName().equals("org.codehaus.groovy.transform.trait.Traits$Implemented")) {
                     methodBuilder.modifiers.remove(Modifier.ABSTRACT);
                     methodBuilder.addModifiers(Modifier.DEFAULT);
@@ -364,8 +361,8 @@ class JavaPoetClassVisitor extends ClassVisitor {
                 }
 
                 String selectedDocumentation = documentation.selected();
-                if (selectedDocumentation == null && generated) {
-                    selectedDocumentation = documentationForGeneratedGroovyAccessor(name, methodType);
+                if (selectedDocumentation == null) {
+                    selectedDocumentation = documentationForGroovyPropertyAccessor(name, methodType);
                 }
                 if (selectedDocumentation != null) {
                     methodBuilder.addJavadoc(filterParams(selectedDocumentation));
@@ -494,6 +491,7 @@ class JavaPoetClassVisitor extends ClassVisitor {
             private final FieldSpec.Builder field = createField();
             private final MemberAnnotationVisitor.DocumentationCarrierSelection documentation =
                     new MemberAnnotationVisitor.DocumentationCarrierSelection();
+            private final GroovyPropertyMappingVisitor propertyMapping = new GroovyPropertyMappingVisitor();
 
             private FieldSpec.Builder createField() {
                 FieldSpec.Builder result = FieldSpec.builder(fieldType, name, TypeConversion.decodeModifiers(access));
@@ -505,13 +503,16 @@ class JavaPoetClassVisitor extends ClassVisitor {
 
             @Override
             public AnnotationVisitor visitAnnotation(String annotationDescriptor, boolean visible) {
+                if (Type.getType(annotationDescriptor).getClassName().equals(GROOVY_PROPERTY_DOCUMENTATION_CLASS)) {
+                    return propertyMapping;
+                }
                 return fieldAnnotationVisitor(annotationDescriptor, documentation, field);
             }
 
             @Override
             public void visitEnd() {
                 addSelectedDocumentation(documentation, field::addJavadoc);
-                rememberGroovyPropertyDocumentation(name, documentation);
+                rememberGroovyPropertyMapping(name, documentation, propertyMapping.mapping());
                 typeBuilder.addField(field.build());
             }
         };
@@ -521,46 +522,79 @@ class JavaPoetClassVisitor extends ClassVisitor {
         return new FieldVisitor(api) {
             private final MemberAnnotationVisitor.DocumentationCarrierSelection documentation =
                     new MemberAnnotationVisitor.DocumentationCarrierSelection();
+            private final GroovyPropertyMappingVisitor propertyMapping = new GroovyPropertyMappingVisitor();
 
             @Override
             public AnnotationVisitor visitAnnotation(String descriptor, boolean visible) {
                 Type annotationType = Type.getType(descriptor);
+                if (annotationType.getClassName().equals(GROOVY_PROPERTY_DOCUMENTATION_CLASS)) {
+                    return propertyMapping;
+                }
                 return documentation.visitor(annotationType);
             }
 
             @Override
             public void visitEnd() {
-                rememberGroovyPropertyDocumentation(name, documentation);
+                rememberGroovyPropertyMapping(name, documentation, propertyMapping.mapping());
             }
         };
     }
 
-    private void rememberGroovyPropertyDocumentation(
-            String fieldName, MemberAnnotationVisitor.DocumentationCarrierSelection documentation) {
+    private void rememberGroovyPropertyMapping(
+            String fieldName, MemberAnnotationVisitor.DocumentationCarrierSelection documentation,
+            GroovyPropertyMapping mapping) {
         if (!groovyClass) return;
         String selectedDocumentation = documentation.selected();
-        if (selectedDocumentation != null) groovyPropertyDocumentation.put(fieldName, selectedDocumentation);
+        if (selectedDocumentation != null && mapping != null) {
+            groovyPropertyMappings.put(fieldName, mapping.withDocumentation(selectedDocumentation));
+        }
     }
 
-    private String documentationForGeneratedGroovyAccessor(String methodName, Type methodType) {
-        String propertyName = generatedAccessorPropertyName(methodName, methodType);
-        return propertyName == null ? null : groovyPropertyDocumentation.get(propertyName);
-    }
-
-    private static String generatedAccessorPropertyName(String methodName, Type methodType) {
-        if (methodName.startsWith("get") && methodName.length() > 3
-                && methodType.getArgumentTypes().length == 0 && methodType.getReturnType().getSort() != Type.VOID) {
-            return Introspector.decapitalize(methodName.substring(3));
-        }
-        if (methodName.startsWith("is") && methodName.length() > 2
-                && methodType.getArgumentTypes().length == 0 && methodType.getReturnType().getSort() == Type.BOOLEAN) {
-            return Introspector.decapitalize(methodName.substring(2));
-        }
-        if (methodName.startsWith("set") && methodName.length() > 3
-                && methodType.getArgumentTypes().length == 1 && methodType.getReturnType().getSort() == Type.VOID) {
-            return Introspector.decapitalize(methodName.substring(3));
+    private String documentationForGroovyPropertyAccessor(String methodName, Type methodType) {
+        for (GroovyPropertyMapping mapping : groovyPropertyMappings.values()) {
+            if (mapping.getters().contains(methodName)
+                    && methodType.getArgumentTypes().length == 0 && methodType.getReturnType().getSort() != Type.VOID) {
+                return mapping.documentation();
+            }
+            if (mapping.setters().contains(methodName)
+                    && methodType.getArgumentTypes().length == 1 && methodType.getReturnType().getSort() == Type.VOID) {
+                return mapping.documentation();
+            }
         }
         return null;
+    }
+
+    private record GroovyPropertyMapping(List<String> getters, List<String> setters, String documentation) {
+        private GroovyPropertyMapping withDocumentation(String documentation) {
+            return new GroovyPropertyMapping(getters, setters, documentation);
+        }
+    }
+
+    private final class GroovyPropertyMappingVisitor extends AnnotationVisitor {
+        private final List<String> getters = new ArrayList<>();
+        private final List<String> setters = new ArrayList<>();
+
+        private GroovyPropertyMappingVisitor() {
+            super(CompilerConfiguration.ASM_API_VERSION);
+        }
+
+        @Override
+        public AnnotationVisitor visitArray(String name) {
+            List<String> target = name.equals("getters") ? getters : name.equals("setters") ? setters : null;
+            if (target == null) return null;
+            return new AnnotationVisitor(api) {
+                @Override
+                public void visit(String ignored, Object value) {
+                    if (value instanceof String accessor) target.add(accessor);
+                }
+            };
+        }
+
+        private GroovyPropertyMapping mapping() {
+            return getters.isEmpty() && setters.isEmpty()
+                    ? null
+                    : new GroovyPropertyMapping(List.copyOf(getters), List.copyOf(setters), null);
+        }
     }
 
     private AnnotationVisitor fieldAnnotationVisitor(

--- a/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/JavaPoetClassVisitor.java
+++ b/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/JavaPoetClassVisitor.java
@@ -30,6 +30,7 @@ import org.objectweb.asm.signature.SignatureReader;
 import org.objectweb.asm.signature.SignatureVisitor;
 
 import javax.lang.model.element.Modifier;
+import java.beans.Introspector;
 import java.io.IOException;
 import java.util.*;
 import java.util.function.Consumer;
@@ -61,6 +62,7 @@ class JavaPoetClassVisitor extends ClassVisitor {
     private boolean recordDeclaration;
     private final List<RecordComponentShape> recordComponents = new ArrayList<>();
     private final List<RecordShape> recordShapes = new ArrayList<>();
+    private final Map<String, String> groovyPropertyDocumentation = new HashMap<>();
 
     JavaPoetClassVisitor(SpecConverter specConverter, ProjectionPolicy policy, Set<String> includedClasses,
                          boolean groovyClass, Set<String> groovyRuntimeMethods, Set<String> groovyRuntimeFields) {
@@ -296,10 +298,14 @@ class JavaPoetClassVisitor extends ClassVisitor {
             final MemberAnnotationVisitor.DocumentationCarrierSelection documentation =
                     new MemberAnnotationVisitor.DocumentationCarrierSelection();
             int visitedParameters;
+            boolean generated;
 
             @Override
             public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
                 Type annotationType = Type.getType(desc);
+                if (annotationType.getClassName().equals("groovy.transform.Generated")) {
+                    generated = true;
+                }
                 if (annotationType.getClassName().equals("org.codehaus.groovy.transform.trait.Traits$Implemented")) {
                     methodBuilder.modifiers.remove(Modifier.ABSTRACT);
                     methodBuilder.addModifiers(Modifier.DEFAULT);
@@ -358,6 +364,9 @@ class JavaPoetClassVisitor extends ClassVisitor {
                 }
 
                 String selectedDocumentation = documentation.selected();
+                if (selectedDocumentation == null && generated) {
+                    selectedDocumentation = documentationForGeneratedGroovyAccessor(name, methodType);
+                }
                 if (selectedDocumentation != null) {
                     methodBuilder.addJavadoc(filterParams(selectedDocumentation));
                 }
@@ -432,8 +441,12 @@ class JavaPoetClassVisitor extends ClassVisitor {
 
     @Override
     public FieldVisitor visitField(int access, String name, String desc, String signature, Object value) {
-        if (!ProjectionSelection.includesField(policy, access, name, typeAccess(),
-                groovyRuntimeFields.contains(ProjectionSelection.memberKey(name, desc)))) return null;
+        boolean included = ProjectionSelection.includesField(policy, access, name, typeAccess(),
+                groovyRuntimeFields.contains(ProjectionSelection.memberKey(name, desc)));
+
+        if (!included) {
+            return groovyClass ? documentationOnlyFieldVisitor(name) : null;
+        }
 
         TypeName fieldType = fieldType(desc, signature);
         if ((access & Opcodes.ACC_ENUM) != 0) return enumConstantVisitor(name);
@@ -498,9 +511,56 @@ class JavaPoetClassVisitor extends ClassVisitor {
             @Override
             public void visitEnd() {
                 addSelectedDocumentation(documentation, field::addJavadoc);
+                rememberGroovyPropertyDocumentation(name, documentation);
                 typeBuilder.addField(field.build());
             }
         };
+    }
+
+    private FieldVisitor documentationOnlyFieldVisitor(String name) {
+        return new FieldVisitor(api) {
+            private final MemberAnnotationVisitor.DocumentationCarrierSelection documentation =
+                    new MemberAnnotationVisitor.DocumentationCarrierSelection();
+
+            @Override
+            public AnnotationVisitor visitAnnotation(String descriptor, boolean visible) {
+                Type annotationType = Type.getType(descriptor);
+                return documentation.visitor(annotationType);
+            }
+
+            @Override
+            public void visitEnd() {
+                rememberGroovyPropertyDocumentation(name, documentation);
+            }
+        };
+    }
+
+    private void rememberGroovyPropertyDocumentation(
+            String fieldName, MemberAnnotationVisitor.DocumentationCarrierSelection documentation) {
+        if (!groovyClass) return;
+        String selectedDocumentation = documentation.selected();
+        if (selectedDocumentation != null) groovyPropertyDocumentation.put(fieldName, selectedDocumentation);
+    }
+
+    private String documentationForGeneratedGroovyAccessor(String methodName, Type methodType) {
+        String propertyName = generatedAccessorPropertyName(methodName, methodType);
+        return propertyName == null ? null : groovyPropertyDocumentation.get(propertyName);
+    }
+
+    private static String generatedAccessorPropertyName(String methodName, Type methodType) {
+        if (methodName.startsWith("get") && methodName.length() > 3
+                && methodType.getArgumentTypes().length == 0 && methodType.getReturnType().getSort() != Type.VOID) {
+            return Introspector.decapitalize(methodName.substring(3));
+        }
+        if (methodName.startsWith("is") && methodName.length() > 2
+                && methodType.getArgumentTypes().length == 0 && methodType.getReturnType().getSort() == Type.BOOLEAN) {
+            return Introspector.decapitalize(methodName.substring(2));
+        }
+        if (methodName.startsWith("set") && methodName.length() > 3
+                && methodType.getArgumentTypes().length == 1 && methodType.getReturnType().getSort() == Type.VOID) {
+            return Introspector.decapitalize(methodName.substring(3));
+        }
+        return null;
     }
 
     private AnnotationVisitor fieldAnnotationVisitor(

--- a/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/GroovyPropertyDocumentationTest.groovy
+++ b/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/GroovyPropertyDocumentationTest.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2026 Stephan Pauxberger
+ * Copyright (c) 2024 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/GroovyPropertyDocumentationTest.groovy
+++ b/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/GroovyPropertyDocumentationTest.groovy
@@ -36,35 +36,50 @@ class GroovyPropertyDocumentationTest extends ClassGeneratingTest {
         createClass('''
             package contract
 
-            import com.blackbuild.annodocimal.annotations.AnnoDoc
+            import com.blackbuild.annodocimal.annotations.InlineJavadocs
 
+            @InlineJavadocs
             class GroovyPropertyFixture {
-                @AnnoDoc('Readable and writable property.')
+                /** Readable and writable property. */
                 String title
 
-                @AnnoDoc('Boolean property.')
+                /** Boolean property. */
                 boolean enabled
 
-                @AnnoDoc('Read-only property.')
+                /** Custom boolean property. */
+                boolean ready
+
+                /** Explicit boolean getter documentation. */
+                boolean isReady() {
+                    ready
+                }
+
+                /** Undocumented custom boolean accessor property. */
+                boolean available
+
+                boolean isAvailable() {
+                    available
+                }
+
+                /** Read-only property. */
                 final String identifier = 'id'
 
-                @AnnoDoc('Write-only property.')
+                /** Write-only property. */
                 private String secret
 
-                @AnnoDoc('Write-only property.')
+                /** Write-only property. */
                 void setSecret(String secret) {
                     this.secret = secret
                 }
 
-                @AnnoDoc('Property documentation.')
+                /** Property documentation. */
                 String endpoint
 
-                @AnnoDoc('Explicit getter documentation.')
+                /** Explicit getter documentation. */
                 String getEndpoint() {
                     endpoint
                 }
 
-                @AnnoDoc('Property documentation.')
                 void setEndpoint(String endpoint) {
                     this.endpoint = endpoint
                 }
@@ -103,10 +118,14 @@ class GroovyPropertyDocumentationTest extends ClassGeneratingTest {
   @Generated
   public void setEnabled(boolean value)''')
         projection.contains('''  /**
-   * Read-only property.
+   * Explicit boolean getter documentation.
    */
-  @Generated
-  public String getIdentifier()''')
+  public boolean isReady()''')
+        projection.contains('''  /**
+   * Undocumented custom boolean accessor property.
+   */
+  public boolean isAvailable()''')
+        projection.find(/(?s)\/\*\*\s+\* Read-only property\.\s+\*\/\s+@Generated\s+public (?:final )?String getIdentifier\(\)/)
         !projection.contains('setIdentifier(')
         projection.contains('''  /**
    * Write-only property.

--- a/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/GroovyPropertyDocumentationTest.groovy
+++ b/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/GroovyPropertyDocumentationTest.groovy
@@ -1,0 +1,129 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2026 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.blackbuild.annodocimal.generator
+
+import spock.lang.Issue
+
+import static com.blackbuild.annodocimal.generator.ProjectionContractAssertions.assertProjectionCompiles
+import static com.google.testing.compile.Compiler.javac
+
+@Issue('9')
+class GroovyPropertyDocumentationTest extends ClassGeneratingTest {
+
+    def 'projection maps Groovy property documentation to generated accessors'() {
+        given:
+        createClass('''
+            package contract
+
+            import com.blackbuild.annodocimal.annotations.AnnoDoc
+
+            class GroovyPropertyFixture {
+                @AnnoDoc('Readable and writable property.')
+                String title
+
+                @AnnoDoc('Boolean property.')
+                boolean enabled
+
+                @AnnoDoc('Read-only property.')
+                final String identifier = 'id'
+
+                @AnnoDoc('Write-only property.')
+                private String secret
+
+                @AnnoDoc('Write-only property.')
+                void setSecret(String secret) {
+                    this.secret = secret
+                }
+
+                @AnnoDoc('Property documentation.')
+                String endpoint
+
+                @AnnoDoc('Explicit getter documentation.')
+                String getEndpoint() {
+                    endpoint
+                }
+
+                @AnnoDoc('Property documentation.')
+                void setEndpoint(String endpoint) {
+                    this.endpoint = endpoint
+                }
+            }
+        ''')
+        def classFile = new File(outputDirectory, 'contract/GroovyPropertyFixture.class').toPath()
+        def projector = new SourceProjector(ProjectionPolicy.documentation())
+
+        when:
+        String projection = projector.projectToText(classFile)
+
+        then:
+        projection.contains('''  /**
+   * Readable and writable property.
+   */
+  @Generated
+  public String getTitle()''')
+        projection.contains('''  /**
+   * Readable and writable property.
+   */
+  @Generated
+  public void setTitle(String value)''')
+        projection.contains('''  /**
+   * Boolean property.
+   */
+  @Generated
+  public boolean getEnabled()''')
+        projection.contains('''  /**
+   * Boolean property.
+   */
+  @Generated
+  public boolean isEnabled()''')
+        projection.contains('''  /**
+   * Boolean property.
+   */
+  @Generated
+  public void setEnabled(boolean value)''')
+        projection.contains('''  /**
+   * Read-only property.
+   */
+  @Generated
+  public final String getIdentifier()''')
+        !projection.contains('setIdentifier(')
+        projection.contains('''  /**
+   * Write-only property.
+   */
+  public void setSecret(String secret)''')
+        projection.contains('''  /**
+   * Explicit getter documentation.
+   */
+  public String getEndpoint()''')
+        projection.contains('''  /**
+   * Property documentation.
+   */
+  public void setEndpoint(String endpoint)''')
+        !projection.contains('Property documentation.\n   */\n  public String getEndpoint()')
+
+        and:
+        assertProjectionCompiles(javac().withOptions('-parameters'), 'groovy-property-documentation',
+                'contract.GroovyPropertyFixture', projection)
+    }
+}

--- a/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/GroovyPropertyDocumentationTest.groovy
+++ b/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/GroovyPropertyDocumentationTest.groovy
@@ -106,7 +106,7 @@ class GroovyPropertyDocumentationTest extends ClassGeneratingTest {
    * Read-only property.
    */
   @Generated
-  public final String getIdentifier()''')
+  public String getIdentifier()''')
         !projection.contains('setIdentifier(')
         projection.contains('''  /**
    * Write-only property.

--- a/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/GroovySourceProjectionContractTest.groovy
+++ b/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/GroovySourceProjectionContractTest.groovy
@@ -29,7 +29,7 @@ import spock.lang.Issue
 import static com.blackbuild.annodocimal.generator.ProjectionContractAssertions.assertProjectionCompiles
 import static com.google.testing.compile.Compiler.javac
 
-@Issue(["41", "19"])
+@Issue(["41", "19", "9"])
 class GroovySourceProjectionContractTest extends ClassGeneratingTest {
 
     def "representative Groovy declaration projection is deterministic and recompilable"() {
@@ -104,11 +104,17 @@ public class GroovyDeclarationFixture<T extends Number> {
     return null;
   }
 
+  /**
+   * Canonical Groovy property documentation
+   */
   @Generated
   public T[] getValues() {
     return null;
   }
 
+  /**
+   * Canonical Groovy property documentation
+   */
   @Generated
   public void setValues(T[] value) {
   }

--- a/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/GroovySourceProjectionContractTest.groovy
+++ b/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/GroovySourceProjectionContractTest.groovy
@@ -39,14 +39,16 @@ class GroovySourceProjectionContractTest extends ClassGeneratingTest {
             package contract
 
             import com.blackbuild.annodocimal.annotations.AnnoDoc
+            import com.blackbuild.annodocimal.annotations.InlineJavadocs
             import groovy.lang.Groovydoc
 
             import java.lang.annotation.Retention
             import java.lang.annotation.RetentionPolicy
 
+            @InlineJavadocs
             @AnnoDoc('Canonical Groovy class documentation')
             class GroovyDeclarationFixture<T extends Number> {
-                @AnnoDoc('Canonical Groovy property documentation')
+                /** Canonical Groovy property documentation */
                 T[] values
 
                 GroovyDeclarationFixture(T[] values) throws IllegalArgumentException {

--- a/docs/user/migration/0.x-to-1.0-authoring-language.md
+++ b/docs/user/migration/0.x-to-1.0-authoring-language.md
@@ -44,6 +44,14 @@ AstDocumentation.attach(target, generated);
 `attach` also filters parameter descriptions against the target's final signature. Template validation completes before
 the carrier is replaced, so a malformed or incomplete template does not partially rewrite existing documentation.
 
+## Groovy property documentation
+
+In 0.x, a Groovy property's source documentation was observable only on its backing field. In 1.0, it is semantic
+property documentation: capture retains it on the backing field, applies it to undocumented custom accessors, and
+source projection applies it to Groovy-generated accessors. Explicit getter and setter documentation has precedence.
+This is not a general JavaBeans inference rule, so unrelated JavaBeans-shaped methods do not gain documentation.
+See the [Groovy property documentation policy](../usage.md#groovy-property-documentation).
+
 Replace implicit template defaults and value-presence conditionals with required `{{key}}` placeholders. Supply values
 explicitly as `String`s through `Map<String, String>`. `{{param:key?fragment}}` is the only conditional form; it omits the fragment only when the
 generated target lacks that parameter. Do not rely on `@template` tags to supply values.

--- a/docs/user/source-projection.md
+++ b/docs/user/source-projection.md
@@ -35,6 +35,11 @@ content is rendered as Javadoc, and neither carrier annotation is copied into th
 properties are compiler-model extraction resources rather than classfile annotations and are therefore outside a
 single-class-file projection input.
 
+For a captured Groovy property, projection carries the backing-field documentation to Groovy-generated `get`, `is`, and
+`set` accessors that exist in the compiled declaration. An accessor's own documentation takes precedence. The association
+requires Groovy-generated-member metadata and the captured backing field; projection does not infer property
+documentation for arbitrary JavaBeans-shaped methods. See the [capture policy](usage.md#groovy-property-documentation).
+
 ## Documentation inclusion policy
 
 `ProjectionPolicy.documentation()` has the stable documentation-oriented defaults:

--- a/docs/user/source-projection.md
+++ b/docs/user/source-projection.md
@@ -35,10 +35,10 @@ content is rendered as Javadoc, and neither carrier annotation is copied into th
 properties are compiler-model extraction resources rather than classfile annotations and are therefore outside a
 single-class-file projection input.
 
-For a captured Groovy property, projection carries the backing-field documentation to Groovy-generated `get`, `is`, and
-`set` accessors that exist in the compiled declaration. An accessor's own documentation takes precedence. The association
-requires Groovy-generated-member metadata and the captured backing field; projection does not infer property
-documentation for arbitrary JavaBeans-shaped methods. See the [capture policy](usage.md#groovy-property-documentation).
+For a captured Groovy property, projection carries the backing-field documentation to the accessor names recorded while
+Groovy's property model was available. An accessor's own documentation takes precedence. The association metadata has no
+documentation content and projection does not infer property documentation for arbitrary JavaBeans-shaped methods. See
+the [capture policy](usage.md#groovy-property-documentation).
 
 ## Documentation inclusion policy
 

--- a/docs/user/supported-api.md
+++ b/docs/user/supported-api.md
@@ -149,6 +149,7 @@ applies Gradle's Groovy plugin and the base layer. Plugin implementation classes
 |---|---|---|
 | `com.blackbuild.annodocimal.annotations.AnnoDoc` | supported | Retain the annotation and `value()` carrier contract. |
 | `com.blackbuild.annodocimal.annotations.InlineJavadocs` | supported | Retain the marker; leave its public suffix constant unsupported. |
+| `com.blackbuild.annodocimal.annotations.GroovyPropertyDocumentation` | implementation-only | Retain as capture-to-projection metadata; documentation content stays in `AnnoDoc`. |
 
 ### APT artifact
 

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -78,6 +78,37 @@ class LocalCapture {
 The marker activates local capture; the transformation, visitor, parser, metadata, and Groovy-version adapter classes
 are implementation-only. `@InlineJavadocs` is source-retained, while `@AnnoDoc` is the runtime documentation carrier.
 
+### Groovy property documentation
+
+Documentation on a Groovy property is semantic property documentation, not documentation for a field selected only by
+its JavaBeans-shaped name. Capture retains the normalized textual carrier on the backing field while the Groovy property
+model is available. An undocumented custom getter or setter receives that property documentation; an explicitly
+documented accessor keeps its own documentation.
+
+```groovy
+@InlineJavadocs
+class DocumentedProperties {
+    /** A service endpoint. */
+    String endpoint
+
+    /** Returns the normalized endpoint. */
+    String getEndpoint() { endpoint }
+
+    void setEndpoint(String endpoint) { this.endpoint = endpoint }
+}
+```
+
+Source projection applies the retained property semantics only to Groovy-generated accessor members. A readable and
+writable property documents its generated getter and setter; a read-only or write-only property documents only the
+accessor that exists. Boolean properties retain the getter forms emitted by the active Groovy compiler. Custom accessors
+use their explicit documentation when present and otherwise use the property documentation. Projection does not attach
+documentation to arbitrary JavaBeans-shaped methods. The carrier remains normalized text; property metadata does not
+introduce the future structured documentation schema.
+
+The executable happy path is
+`GroovyPropertyDocumentationDocumentaryTest.captures property documentation and respects explicit accessor documentation`
+(issue #9).
+
 ### Global Groovy capture
 
 To enable capture by Groovy global-AST service discovery, add the global artifact to the compilation that processes

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -81,9 +81,10 @@ are implementation-only. `@InlineJavadocs` is source-retained, while `@AnnoDoc` 
 ### Groovy property documentation
 
 Documentation on a Groovy property is semantic property documentation, not documentation for a field selected only by
-its JavaBeans-shaped name. Capture retains the normalized textual carrier on the backing field while the Groovy property
-model is available. An undocumented custom getter or setter receives that property documentation; an explicitly
-documented accessor keeps its own documentation.
+its JavaBeans-shaped name. Capture retains the normalized textual carrier on the backing field and classfile metadata
+that names its associated accessors while the Groovy property model is available. The metadata contains no documentation
+content and does not change the textual carrier. An undocumented custom getter or setter receives that property
+documentation; an explicitly documented accessor keeps its own documentation.
 
 ```groovy
 @InlineJavadocs
@@ -98,12 +99,12 @@ class DocumentedProperties {
 }
 ```
 
-Source projection applies the retained property semantics only to Groovy-generated accessor members. A readable and
-writable property documents its generated getter and setter; a read-only or write-only property documents only the
-accessor that exists. Boolean properties retain the getter forms emitted by the active Groovy compiler. Custom accessors
-use their explicit documentation when present and otherwise use the property documentation. Projection does not attach
-documentation to arbitrary JavaBeans-shaped methods. The carrier remains normalized text; property metadata does not
-introduce the future structured documentation schema.
+Source projection consumes that captured association. A readable and writable property documents its generated getter
+and setter; a read-only or write-only property documents only the accessor that exists. Boolean properties retain the
+getter forms emitted by the active Groovy compiler. Custom accessors use their explicit documentation when present and
+otherwise use the property documentation. Projection does not attach documentation to arbitrary JavaBeans-shaped
+methods. The carrier remains normalized text; the association metadata does not introduce the future structured
+documentation schema.
 
 The executable happy path is
 `GroovyPropertyDocumentationDocumentaryTest.captures property documentation and respects explicit accessor documentation`


### PR DESCRIPTION
## Summary

- Capture Groovy property-to-accessor associations while the Groovy property model is available.
- Preserve normalized documentation text in `@AnnoDoc`; projection consumes captured association metadata rather than JavaBeans inference.
- Define explicit accessor precedence and cover readable, writable, read-only, write-only, boolean, and custom forms across Groovy 3/4/5.
- Document the behavior in the README, usage guide, source-projection guide, migration guide, and changelog.

## Validation

- `./gradlew check`
- Standards and spec reviews

Related: #9

A maintainer may separately add the documentary-test and usage-guide references to issue #9; this PR leaves issue state unchanged.
