### PR TITLE
Codex/issue 46 diagnosable ci evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,13 +45,9 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v6
       - name: Verify Gradle 7.3.3 and strict configuration-cache reuse
-        run: >-
-          ./gradlew :anno-docimal-gradle-plugin:test
-          --tests '*the documented Gradle minimum supports the reusable task and configuration cache'
+        run: ./gradlew :anno-docimal-gradle-plugin:test -Pannodocimal.ci.test-tag=ci-supported-gradle-minimum
       - name: Verify wrapper Gradle 8.14.5 and strict configuration-cache reuse
-        run: >-
-          ./gradlew :anno-docimal-gradle-plugin:test
-          --tests '*source mirror stores and reuses the strict configuration cache'
+        run: ./gradlew :anno-docimal-gradle-plugin:test -Pannodocimal.ci.test-tag=ci-current-gradle-configuration-cache
 
   capture-and-projection-contracts:
     name: Capture and source-projection contract suites

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,19 +11,101 @@ permissions:
   contents: read
 
 jobs:
-  build:
-
+  java17-and-groovy-compatibility:
+    name: Java 17 and Groovy compatibility
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Java 17 toolchain
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+      - name: Verify Java 17 runtime and toolchain
+        run: ./gradlew --version
+      - name: Verify Groovy 3 baseline compatibility
+        run: ./gradlew test jacocoTestReport
+      - name: Verify Groovy 4 compatibility
+        run: ./gradlew groovy4Tests
+      - name: Verify Groovy 5 compatibility
+        run: ./gradlew groovy5Tests
 
+  supported-gradle-and-configuration-cache:
+    name: Supported Gradle range and strict configuration cache
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Java 17 toolchain
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+      - name: Verify Gradle 7.3.3 and strict configuration-cache reuse
+        run: >-
+          ./gradlew :anno-docimal-gradle-plugin:test
+          --tests '*the documented Gradle minimum supports the reusable task and configuration cache'
+      - name: Verify wrapper Gradle 8.14.5 and strict configuration-cache reuse
+        run: >-
+          ./gradlew :anno-docimal-gradle-plugin:test
+          --tests '*source mirror stores and reuses the strict configuration cache'
+
+  capture-and-projection-contracts:
+    name: Capture and source-projection contract suites
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Java 17 toolchain
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+      - name: Verify capture conformance across Groovy 3, 4, and 5
+        run: >-
+          ./gradlew
+          :anno-docimal-global-ast:test
+          :anno-docimal-global-ast:groovy4Tests
+          :anno-docimal-global-ast:groovy5Tests
+          --tests '*CapturePathConformanceTest'
+      - name: Verify source-projection contracts across Groovy 3, 4, and 5
+        run: >-
+          ./gradlew
+          :anno-docimal-generator:test
+          :anno-docimal-generator:groovy4Tests
+          :anno-docimal-generator:groovy5Tests
+          --tests '*SourceProjectionContractTest'
+
+  publication-and-consumer-smoke:
+    name: Clean publication and consumer smoke tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Java 17 toolchain
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+      - name: Verify clean local publication and Gradle/Maven consumers
+        run: ./gradlew :publication-smoke-tests:test
+
+  supplementary-sonar-analysis:
+    name: Supplementary Sonar analysis
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up JDK
+      - name: Set up Java 17 toolchain
         uses: actions/setup-java@v5
         with:
-          java-version: |
-            17
+          java-version: '17'
           distribution: 'adopt'
       - name: Cache SonarCloud packages
         uses: actions/cache@v6
@@ -31,14 +113,12 @@ jobs:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
-      - name: Setup Gradle
+      - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v6
-      - name: Verify Gradle JVM is Java 17
-        run: ./gradlew --version
-      - name: Build and produce coverage with Java 17
-        run: ./gradlew build jacocoTestReport
+      - name: Produce Java 17 baseline coverage for analysis
+        run: ./gradlew jacocoTestReport
       - name: Analyze with auto-provisioned Sonar JRE
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: ./gradlew sonar --info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,10 +44,8 @@ jobs:
           distribution: 'adopt'
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v6
-      - name: Verify Gradle 7.3.3 and strict configuration-cache reuse
-        run: ./gradlew :anno-docimal-gradle-plugin:test -Pannodocimal.ci.test-tag=ci-supported-gradle-minimum
-      - name: Verify wrapper Gradle 8.14.5 and strict configuration-cache reuse
-        run: ./gradlew :anno-docimal-gradle-plugin:test -Pannodocimal.ci.test-tag=ci-current-gradle-configuration-cache
+      - name: Verify Gradle 7.3.3 and wrapper 8.14.5 configuration-cache compatibility
+        run: ./gradlew :anno-docimal-gradle-plugin:test -Pannodocimal.test-tag=compatibility-gradle
 
   capture-and-projection-contracts:
     name: Capture and source-projection contract suites

--- a/anno-docimal-gradle-plugin/build.gradle
+++ b/anno-docimal-gradle-plugin/build.gradle
@@ -41,8 +41,13 @@ dependencies {
     testImplementation libs.spock.g3
 }
 
+def ciTestTag = providers.gradleProperty('annodocimal.ci.test-tag')
+
 test {
-    useJUnitPlatform()
+    useJUnitPlatform {
+        if (ciTestTag.present)
+            includeTags(ciTestTag.get())
+    }
     inputs.files(project(":anno-docimal-ast").tasks.named("jar"), project(":anno-docimal-annotations").tasks.named("jar"))
 
     doFirst {

--- a/anno-docimal-gradle-plugin/build.gradle
+++ b/anno-docimal-gradle-plugin/build.gradle
@@ -41,12 +41,12 @@ dependencies {
     testImplementation libs.spock.g3
 }
 
-def ciTestTag = providers.gradleProperty('annodocimal.ci.test-tag')
+def selectedTestTag = providers.gradleProperty('annodocimal.test-tag')
 
 test {
     useJUnitPlatform {
-        if (ciTestTag.present)
-            includeTags(ciTestTag.get())
+        if (selectedTestTag.present)
+            includeTags(selectedTestTag.get())
     }
     inputs.files(project(":anno-docimal-ast").tasks.named("jar"), project(":anno-docimal-annotations").tasks.named("jar"))
 

--- a/anno-docimal-gradle-plugin/src/test/groovy/com/blackbuild/annodocimal/plugin/AnnoDocimalPluginTest.groovy
+++ b/anno-docimal-gradle-plugin/src/test/groovy/com/blackbuild/annodocimal/plugin/AnnoDocimalPluginTest.groovy
@@ -113,7 +113,8 @@ class AnnoDocimalPluginTest extends Specification {
     }
 
     @Issue("35")
-    @Tag('ci-current-gradle-configuration-cache')
+    @Tag('compatibility-gradle')
+    @Tag('gradle-configuration-cache')
     def "source mirror stores and reuses the strict configuration cache"() {
         given:
         prepareMirrorProject()
@@ -144,7 +145,8 @@ class AnnoDocimalPluginTest extends Specification {
     }
 
     @Issue("35")
-    @Tag('ci-supported-gradle-minimum')
+    @Tag('compatibility-gradle')
+    @Tag('gradle-configuration-cache')
     def "the documented Gradle minimum supports the reusable task and configuration cache"() {
         given:
         prepareMirrorProject()

--- a/anno-docimal-gradle-plugin/src/test/groovy/com/blackbuild/annodocimal/plugin/AnnoDocimalPluginTest.groovy
+++ b/anno-docimal-gradle-plugin/src/test/groovy/com/blackbuild/annodocimal/plugin/AnnoDocimalPluginTest.groovy
@@ -28,6 +28,7 @@ import org.gradle.testkit.runner.GradleRunner
 import spock.lang.Issue
 import spock.lang.Shared
 import spock.lang.Specification
+import spock.lang.Tag
 import spock.lang.TempDir
 
 class AnnoDocimalPluginTest extends Specification {
@@ -112,6 +113,7 @@ class AnnoDocimalPluginTest extends Specification {
     }
 
     @Issue("35")
+    @Tag('ci-current-gradle-configuration-cache')
     def "source mirror stores and reuses the strict configuration cache"() {
         given:
         prepareMirrorProject()
@@ -142,6 +144,7 @@ class AnnoDocimalPluginTest extends Specification {
     }
 
     @Issue("35")
+    @Tag('ci-supported-gradle-minimum')
     def "the documented Gradle minimum supports the reusable task and configuration cache"() {
         given:
         prepareMirrorProject()

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -42,6 +42,22 @@ Source-projection changes require exact generated-source assertions for affected
 The Gradle integration must document and verify a supported Gradle range. Use the wrapper as the primary development
 baseline and test the documented minimum separately. Raising that minimum is a breaking compatibility change.
 
+## Semantic test tags
+
+Use Spock/JUnit Platform `@Tag` annotations to identify stable, semantic test cohorts. A tag describes the contract or
+purpose under test, never the execution environment, a CI job, or an incidental test implementation detail. Tags are
+lowercase and hyphenated.
+
+- `compatibility-<subject>` identifies a cohort that proves a supported compatibility boundary, for example
+  `compatibility-gradle`, `compatibility-java`, or `compatibility-intellij` when that product has such a cohort.
+- `<subject>-<capability>` identifies a narrower, orthogonal guarantee. A Gradle compatibility test that proves
+  configuration-cache behavior therefore carries both `compatibility-gradle` and `gradle-configuration-cache`.
+- `documentary` remains the established tag for readable user-facing happy paths; it is not a compatibility tag.
+
+Tags may select focused work through a supported test-engine mechanism, but remain optional metadata where a
+compatibility lane cannot select them. Tag selection must never suppress a required compatibility lane. Introduce tags
+prospectively for a concrete cohort; do not retrofit a suite merely to make its vocabulary uniform.
+
 ## Issue traceability
 
 Every newly added test must carry Spock's `@Issue` annotation with the number of its driving GitHub issue. When one issue

--- a/docs/implementation/1.0-release-plan.md
+++ b/docs/implementation/1.0-release-plan.md
@@ -77,7 +77,8 @@ aggregate build as their only evidence:
   the Groovy 3 baseline and Groovy 4 and 5 compatibility suites.
 - **Supported Gradle range and strict configuration cache** runs the measured Gradle 7.3.3 minimum and the 8.14.5
   wrapper baseline through the reusable `SourceProjectionTask` scenario, requiring configuration-cache storage and
-  reuse with configuration-cache problems treated as failures.
+  reuse with configuration-cache problems treated as failures. The CI invocation selects each scenario through its
+  stable Spock/JUnit Platform tag, not a quoted feature name.
 - **Capture and source-projection contract suites** runs the capture conformance and recompiling source-projection
   contracts across Groovy 3, 4, and 5.
 - **Clean publication and consumer smoke tests** runs the unsigned local publication audit and clean Gradle and Maven

--- a/docs/implementation/1.0-release-plan.md
+++ b/docs/implementation/1.0-release-plan.md
@@ -68,6 +68,24 @@ The tracker and every hard gate belong to a dedicated GitHub `1.0` milestone; la
   4.0 must not release against provisional AnnoDocimal 0.x APIs. No KlumAST issue or release plan is mutated from this
   repository session (ADR 0030).
 
+## CI evidence lanes
+
+The CI workflow exposes the 1.0 compatibility promises as named, diagnosable checks rather than treating a single
+aggregate build as their only evidence:
+
+- **Java 17 and Groovy compatibility** verifies the Java 17 runtime/toolchain contract and has separate named steps for
+  the Groovy 3 baseline and Groovy 4 and 5 compatibility suites.
+- **Supported Gradle range and strict configuration cache** runs the measured Gradle 7.3.3 minimum and the 8.14.5
+  wrapper baseline through the reusable `SourceProjectionTask` scenario, requiring configuration-cache storage and
+  reuse with configuration-cache problems treated as failures.
+- **Capture and source-projection contract suites** runs the capture conformance and recompiling source-projection
+  contracts across Groovy 3, 4, and 5.
+- **Clean publication and consumer smoke tests** runs the unsigned local publication audit and clean Gradle and Maven
+  consumer fixtures from issue #44.
+
+**Supplementary Sonar analysis** uses Java 17 producer outputs and SonarScanner's auto-provisioned analysis JRE. It is
+static-analysis evidence only; it does not replace any behavioral compatibility, contract, or publication check.
+
 ## Confirmed non-gates
 
 - Issue #30 does not block 1.0. Structured annotations target a future 2.0 release with a separate ecosystem migration

--- a/docs/implementation/1.0-release-plan.md
+++ b/docs/implementation/1.0-release-plan.md
@@ -77,8 +77,9 @@ aggregate build as their only evidence:
   the Groovy 3 baseline and Groovy 4 and 5 compatibility suites.
 - **Supported Gradle range and strict configuration cache** runs the measured Gradle 7.3.3 minimum and the 8.14.5
   wrapper baseline through the reusable `SourceProjectionTask` scenario, requiring configuration-cache storage and
-  reuse with configuration-cache problems treated as failures. The CI invocation selects each scenario through its
-  stable Spock/JUnit Platform tag, not a quoted feature name.
+  reuse with configuration-cache problems treated as failures. The CI invocation selects the stable
+  `compatibility-gradle` Spock/JUnit Platform cohort, not quoted feature names; its individual results identify each
+  Gradle endpoint, and both scenarios carry the narrower `gradle-configuration-cache` guarantee.
 - **Capture and source-projection contract suites** runs the capture conformance and recompiling source-projection
   contracts across Groovy 3, 4, and 5.
 - **Clean publication and consumer smoke tests** runs the unsigned local publication audit and clean Gradle and Maven

--- a/docs/publication-validation.md
+++ b/docs/publication-validation.md
@@ -36,6 +36,10 @@ publish task, a Plugin Portal task, or a signing task. It verifies:
 - clean, offline Gradle and Apache Maven consumers resolving all six coordinates. The Gradle fixture also applies both
   plugin IDs. The Maven runtime is a pinned build-tool dependency and uses a fresh isolated local repository.
 
+CI exposes this same audit as the **Clean publication and consumer smoke tests** check. Its result is behavioral
+evidence for the local publication contract; a passing Sonar analysis is supplementary static analysis and never
+substitutes for this check.
+
 `verifyPublicationReleaseConfiguration`, included in the root `check`, inspects the signing tasks for every Maven
 publication, the Maven Central staging and snapshot endpoints, and the Gradle Plugin Portal publication task. It does
 not read signing credentials, create signatures, open a staging repository, or publish anything.


### PR DESCRIPTION
## What changed

Makes the existing 1.0 compatibility promises observable as distinct CI evidence:

- Java 17 plus separately named Groovy 3, 4, and 5 compatibility results
- supported minimum Gradle and current-wrapper compatibility through the semantic `compatibility-gradle` cohort
- strict configuration-cache storage/reuse evidence through `gradle-configuration-cache`
- explicit capture/source-projection and clean publication/consumer-smoke lanes
- documentation of each lane and Sonar analysis as non-substitutive behavioral evidence

## Why

Related: #46

This makes compatibility and release promises diagnosable when a CI lane fails, without creating a one-job-per-version topology.

## Validation

- `./gradlew :anno-docimal-gradle-plugin:test -Pannodocimal.test-tag=compatibility-gradle`
- `./gradlew check`
- YAML parse and `git diff --check`
- final Standards review: no findings
- final Spec review: no findings

The branch was cleanly rebased onto current `master` before publication.

## Publication audit

- Branch push succeeded: `codex/issue-46-diagnosable-ci-evidence`
- Local GitHub CLI authentication reported an invalid active token.
- Connected GitHub integration PR creation returned `403 Resource not accessible by integration`.
- No credentials were changed and no GitHub metadata was mutated by the agent.