### PR TITLE
Realign disposable Pages rehearsal

### DIFF
--- a/.github/workflows/rehearse-versioned-documentation.yml
+++ b/.github/workflows/rehearse-versioned-documentation.yml
@@ -7,11 +7,6 @@ on:
         description: Exact lowercase source commit SHA
         required: true
         type: string
-      deploy:
-        description: Retain this non-release rehearsal on the protected Pages ledger
-        required: true
-        default: false
-        type: boolean
 
 permissions:
   contents: read
@@ -19,19 +14,14 @@ permissions:
 jobs:
   render-and-crawl:
     runs-on: ubuntu-latest
-    outputs:
-      exact_path: ${{ steps.identity.outputs.exact_path }}
-      render_path: ${{ steps.identity.outputs.render_path }}
     steps:
-      - id: identity
+      - name: Validate exact source revision
         shell: bash
         env:
           REVISION: ${{ inputs.revision }}
         run: |
           set -euo pipefail
           [[ "$REVISION" =~ ^[0-9a-f]{40}$ ]]
-          echo "exact_path=rehearsal/commonmark-java-static-html-v1/$REVISION" >> "$GITHUB_OUTPUT"
-          echo "render_path=local-rehearsal" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -73,38 +63,3 @@ jobs:
           name: documentation-presentation-rehearsal
           path: build/versioned-documentation/rehearsal-review
           if-no-files-found: error
-
-  retain-on-pages:
-    if: inputs.deploy
-    needs: render-and-crawl
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          name: documentation-presentation-rehearsal
-          path: rendered
-      - uses: actions/checkout@v4
-        with:
-          ref: gh-pages
-          path: pages
-          fetch-depth: 1
-      - name: Add one immutable non-release rehearsal
-        shell: bash
-        env:
-          EXACT_PATH: ${{ needs.render-and-crawl.outputs.exact_path }}
-          RENDER_PATH: ${{ needs.render-and-crawl.outputs.render_path }}
-        run: |
-          set -euo pipefail
-          test ! -e "pages/$EXACT_PATH"
-          mkdir -p "pages/$(dirname "$EXACT_PATH")"
-          mv "rendered/$RENDER_PATH" "pages/$EXACT_PATH"
-          touch pages/.nojekyll
-          git -C pages config user.name github-actions[bot]
-          git -C pages config user.email 41898282+github-actions[bot]@users.noreply.github.com
-          git -C pages add "$EXACT_PATH" .nojekyll
-          git -C pages commit -m "Retain documentation rehearsal $EXACT_PATH"
-          git -C pages push origin HEAD:gh-pages

--- a/docs/implementation/cross-library-pages-rehearsal-alignment.md
+++ b/docs/implementation/cross-library-pages-rehearsal-alignment.md
@@ -1,0 +1,74 @@
+# Cross-library Pages rehearsal alignment
+
+Date: 2026-07-24
+
+This is a research note for AnnoDocimal #71. It records current first-party
+repository and GitHub state; it neither authorizes nor performs a remote
+configuration or publication action.
+
+## Finding
+
+KlumAST's accepted contract is the disposable platform-rehearsal model: before
+creating its canonical protected `gh-pages` ledger, maintainers may publish one
+generated, non-release site for manual evaluation, then deactivate Pages and
+delete the entire experimental branch. It must not use a release-like
+`pending/<version>/<sha>/` path and creates no immutable release evidence.
+[KlumAST ADR 0013](https://github.com/klum-dsl/klum-ast/blob/master/docs/adr/0013-versioned-documentation-and-javadocs.md)
+and its [release runbook](https://github.com/klum-dsl/klum-ast/blob/master/RELEASING.md)
+state that sequence explicitly. It was accepted through
+[KlumAST PR #542](https://github.com/klum-dsl/klum-ast/pull/542).
+
+That is a design decision, not completed KlumAST rehearsal evidence. KlumAST
+#456 remains open; its VD-1 PR expressly excluded Pages deployment, and its
+VD-5 evidence says that no rehearsal or Pages deployment was performed.
+([#456](https://github.com/klum-dsl/klum-ast/issues/456),
+[PR #537](https://github.com/klum-dsl/klum-ast/pull/537),
+[VD-5 evidence](https://github.com/klum-dsl/klum-ast/blob/master/docs/implementation/evidence/issue-456-vd5-pending-pages-stage.md)).
+The live GitHub Pages and `gh-pages` endpoints were unavailable when checked;
+therefore this note does not claim that KlumAST has executed the teardown.
+
+KlumCast supplies no contrary operational model. Its #47 is a post-KlumAST-4.0
+planning issue that still needs to select KlumCast-local Pages mechanics;
+current repository workflows contain no Pages workflow, and its live Pages and
+`gh-pages` endpoints were unavailable when checked.
+([KlumCast #47](https://github.com/klum-dsl/klum-cast/issues/47))
+
+## Difference in AnnoDocimal
+
+AnnoDocimal #71 requires a *non-publishing* rehearsal, rather than durable
+non-release Pages evidence. ([#71](https://github.com/blackbuild/anno-docimal/issues/71))
+At the start of this research, merged implementation defined an opt-in `deploy` mode that
+added a previously absent, immutable
+`rehearsal/commonmark-java-static-html-v1/<full-sha>/` tree to `gh-pages`.
+([rehearsal workflow](https://github.com/blackbuild/anno-docimal/blob/master/.github/workflows/rehearse-versioned-documentation.yml),
+[versioned-documentation guide](https://github.com/blackbuild/anno-docimal/blob/master/docs/versioned-documentation.md),
+[publication validation](https://github.com/blackbuild/anno-docimal/blob/master/docs/publication-validation.md))
+That retained-ledger behavior is inconsistent with the KlumAST disposable
+platform-rehearsal decision and with the stated intent to remove the generated
+first rehearsal site. Issue #71 was subsequently amended to select the
+disposable pre-ledger model; its implementation must remove that retained
+deployment seam.
+
+## Recommended coordinated adjustment
+
+Adopt the KlumAST model for AnnoDocimal's first external Pages rehearsal:
+
+1. Render and validate a clearly non-release, non-`pending` site from an exact
+   source revision, then temporarily serve it only for manual presentation and
+   deep-link verification.
+2. Record the result and the exact revision in #71, retaining only the normal
+   workflow artifact/evidence permitted by its retention policy—not a Pages
+   ledger entry or release-evidence path.
+3. Deactivate Pages and delete the entire experimental branch after validation.
+4. Only afterwards create a fresh orphan `.nojekyll` `gh-pages` ledger, apply
+   the separately agreed protections/environments, and use it exclusively for
+   future authorized immutable release evidence.
+
+This preserves the release boundary: #45 remains the owner of release
+authorization, publication ordering, recovery, RC/final publication, and
+successor records. The change also removes the present contradiction between a
+disposable first rehearsal and a retained rehearsal namespace. It does **not**
+resolve the separate workflow-writer/branch-protection gap; that needs its own
+least-privilege authentication decision before any canonical ledger deployment.
+
+No remote mutation or AnnoDocimal policy change was made for this research.

--- a/docs/implementation/cross-library-pages-rehearsal-alignment.md
+++ b/docs/implementation/cross-library-pages-rehearsal-alignment.md
@@ -51,15 +51,17 @@ deployment seam.
 
 ## Recommended coordinated adjustment
 
-Adopt the KlumAST model for AnnoDocimal's first external Pages rehearsal:
+Adopt the KlumAST model for AnnoDocimal's external Pages rehearsals:
 
-1. Render and validate a clearly non-release, non-`pending` site from an exact
-   source revision, then temporarily serve it only for manual presentation and
-   deep-link verification.
-2. Record the result and the exact revision in #71, retaining only the normal
+1. Render and validate clearly non-release, non-`pending` sites from exact
+   source revisions, then temporarily serve them only for manual presentation
+   and deep-link verification until one result is accepted.
+2. Record each result and exact revision in #71, retaining only the normal
    workflow artifact/evidence permitted by its retention policy—not a Pages
    ledger entry or release-evidence path.
-3. Deactivate Pages and delete the entire experimental branch after validation.
+3. Keep the experimental Pages boundary unprotected while rehearsals repeat to
+   address found problems. After the first verified and accepted result,
+   deactivate Pages and delete the entire experimental branch.
 4. Only afterwards create a fresh orphan `.nojekyll` `gh-pages` ledger, apply
    the separately agreed protections/environments, and use it exclusively for
    future authorized immutable release evidence.

--- a/docs/publication-validation.md
+++ b/docs/publication-validation.md
@@ -65,5 +65,6 @@ an RC successor status record; that mutable root record is the only permitted po
 rewrites an RC snapshot or manifest. A `pending` candidate or final documentation render may provide protected,
 unlisted pre-publication evidence, but it authorizes no artifact publication, public status record, or navigation alias.
 That single-use pending evidence is distinct from the disposable, non-release static-HTML presentation rehearsal. Its
-local artifact is selected from `local-rehearsal/`; accepted platform evidence is
-retained under `rehearsal/commonmark-java-static-html-v1/<revision>/`.
+local artifact is selected from `local-rehearsal/`; a one-time maintainer-led platform rehearsal may temporarily use
+that artifact from a clearly experimental Pages branch, but records its validation in #71 and removes the branch after
+Pages is deactivated. It is not retained on the canonical Pages ledger.

--- a/docs/publication-validation.md
+++ b/docs/publication-validation.md
@@ -65,6 +65,7 @@ an RC successor status record; that mutable root record is the only permitted po
 rewrites an RC snapshot or manifest. A `pending` candidate or final documentation render may provide protected,
 unlisted pre-publication evidence, but it authorizes no artifact publication, public status record, or navigation alias.
 That single-use pending evidence is distinct from the disposable, non-release static-HTML presentation rehearsal. Its
-local artifact is selected from `local-rehearsal/`; a one-time maintainer-led platform rehearsal may temporarily use
-that artifact from a clearly experimental Pages branch, but records its validation in #71 and removes the branch after
-Pages is deactivated. It is not retained on the canonical Pages ledger.
+local artifact is selected from `local-rehearsal/`; one or more maintainer-led platform rehearsals may temporarily use
+that artifact from a clearly experimental Pages branch. They record each validation in #71 and keep Pages unprotected
+until the first result is verified and accepted, after which Pages is deactivated and the branch is removed. They are not
+retained on the canonical Pages ledger.

--- a/docs/versioned-documentation.md
+++ b/docs/versioned-documentation.md
@@ -93,12 +93,13 @@ The separate presentation-rehearsal workflow is artifact-only. It renders and cr
 the result; it has no Pages write permission and no deployment input. It writes no version status, alias, release
 record, pending path, or Pages tree. Merging the workflow neither configures Pages nor dispatches it.
 
-One maintainer-authorized platform rehearsal may use that generated artifact to populate a clearly experimental branch
-for manual Pages inspection. It is neither release evidence nor a protected ledger entry: it uses no `pending` or
-release-snapshot path, and its exact revision and validation result are recorded in issue #71. After inspection, set
-the Pages source to `None` and delete the complete experimental branch. Only after that teardown may a fresh orphan
-`gh-pages` branch with root `.nojekyll` become the protected canonical ledger. The workflow never automates either
-Pages configuration or this deletion.
+One or more maintainer-authorized platform rehearsals may use that generated artifact to populate a clearly experimental
+branch for manual Pages inspection. They are neither release evidence nor protected ledger entries: they use no `pending`
+or release-snapshot path, and each exact revision and validation result is recorded in issue #71. If a rehearsal reveals
+a problem, correct it and rehearse again on the experimental boundary. Pages and its branch remain unprotected until the
+first rehearsal result is verified and accepted; then set the Pages source to `None` and delete the complete experimental
+branch. Only after that teardown may a fresh orphan `gh-pages` branch with root `.nojekyll` become the protected canonical
+ledger. The workflow never automates either Pages configuration or this deletion.
 
 ## Explicit release render
 

--- a/docs/versioned-documentation.md
+++ b/docs/versioned-documentation.md
@@ -89,10 +89,16 @@ Inspect it in a browser under the real Pages base path with:
 
 The task prints a loopback `/anno-docimal/` URL and runs until interrupted.
 
-The separate presentation-rehearsal workflow maps that exact local tree to accepted platform evidence only at
-`/rehearsal/commonmark-java-static-html-v1/<revision>/`. It does not deploy the local selector. Deployment is opt-in and
-protected; the workflow defaults to a read-only render/crawl artifact. It writes no version status, alias, release
-record, or pending path. Merging the workflow neither configures Pages nor dispatches it.
+The separate presentation-rehearsal workflow is artifact-only. It renders and crawls the exact local tree, then uploads
+the result; it has no Pages write permission and no deployment input. It writes no version status, alias, release
+record, pending path, or Pages tree. Merging the workflow neither configures Pages nor dispatches it.
+
+One maintainer-authorized platform rehearsal may use that generated artifact to populate a clearly experimental branch
+for manual Pages inspection. It is neither release evidence nor a protected ledger entry: it uses no `pending` or
+release-snapshot path, and its exact revision and validation result are recorded in issue #71. After inspection, set
+the Pages source to `None` and delete the complete experimental branch. Only after that teardown may a fresh orphan
+`gh-pages` branch with root `.nojekyll` become the protected canonical ledger. The workflow never automates either
+Pages configuration or this deletion.
 
 ## Explicit release render
 


### PR DESCRIPTION
## Summary

- remove the workflow path that retained a non-release rehearsal on `gh-pages`
- keep the exact-revision render/crawl workflow artifact-only
- document KlumAST-aligned temporary experimental-branch validation and teardown
- record the cross-library primary-source evidence

## Why

Related: #71. The issue now requires a disposable pre-ledger platform rehearsal, not durable non-release Pages evidence. #45 remains the owner of release authorization, ordering, recovery, RC/final publication, and successor records.

## Validation

- `./gradlew :publication-smoke-tests:test --tests com.blackbuild.annodocimal.docs.VersionedDocumentationDocumentaryTest`
- `git diff --check origin/master...HEAD`
- Ruby YAML parse of `.github/workflows/rehearse-versioned-documentation.yml`

No GitHub Pages settings, environments, releases, tags, or artifacts were changed.
