### PR TITLE
Protect canonical Pages App writer

### DIFF
--- a/.github/workflows/publish-versioned-documentation.yml
+++ b/.github/workflows/publish-versioned-documentation.yml
@@ -42,6 +42,7 @@ jobs:
   validate-and-render:
     runs-on: ubuntu-latest
     outputs:
+      revision: ${{ steps.validate.outputs.revision }}
       version: ${{ steps.validate.outputs.version }}
       status: ${{ steps.validate.outputs.status }}
       render_path: ${{ steps.validate.outputs.render_path }}
@@ -77,6 +78,7 @@ jobs:
             [[ "$STATUS" == current ]]
             [[ "$SUCCESSOR_OF" =~ ^[0-9]+\.[0-9]+\.[0-9]+-rc\.[1-9][0-9]*$ ]]
           fi
+          echo "revision=$REVISION" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "status=$STATUS" >> "$GITHUB_OUTPUT"
           if [[ "$STATUS" == pending ]]; then
@@ -151,24 +153,52 @@ jobs:
           path: build/versioned-documentation
           if-no-files-found: error
 
-  deploy-immutable-snapshot:
+  write-canonical-immutable-snapshot:
     if: inputs.deploy
     needs: validate-and-render
     runs-on: ubuntu-latest
     environment:
       name: github-pages
     permissions:
-      contents: write
+      contents: read
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Require the requested source to be current master
+        shell: bash
+        env:
+          REVISION: ${{ needs.validate-and-render.outputs.revision }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse "$REVISION^{commit}")" = "$REVISION"
+          master_revision="$(git ls-remote --exit-code origin refs/heads/master | awk '{print $1}')"
+          test "$master_revision" = "$REVISION"
       - uses: actions/download-artifact@v4
         with:
           name: versioned-documentation
           path: rendered
+      - name: Assert the staged artifact is bound to the requested source
+        shell: bash
+        env:
+          REVISION: ${{ needs.validate-and-render.outputs.revision }}
+          VERSION: ${{ needs.validate-and-render.outputs.version }}
+          STATUS: ${{ needs.validate-and-render.outputs.status }}
+          RENDER_PATH: ${{ needs.validate-and-render.outputs.render_path }}
+        run: |
+          set -euo pipefail
+          manifest="rendered/$RENDER_PATH/source-manifest.json"
+          test -f "$manifest"
+          jq -e --arg revision "$REVISION" --arg version "$VERSION" --arg status "$STATUS" \
+            '.source.revision == $revision and .documentation.version == $version and .documentation.status == $status' \
+            "$manifest" >/dev/null
       - uses: actions/checkout@v4
         with:
           ref: gh-pages
           path: pages
           fetch-depth: 1
+          persist-credentials: false
       - name: Add one previously absent exact snapshot
         shell: bash
         env:
@@ -192,4 +222,52 @@ jobs:
           git -C pages add .nojekyll
           if [[ "$STATUS" != pending ]]; then git -C pages add status; fi
           git -C pages commit -m "Publish immutable documentation snapshot $SNAPSHOT_PATH"
-          git -C pages push origin HEAD:gh-pages
+          echo "pushed_commit=$(git -C pages rev-parse HEAD)" >> "$GITHUB_ENV"
+      - name: Require protected writer credentials
+        shell: bash
+        env:
+          PAGES_WRITER_APP_ID: ${{ secrets.PAGES_WRITER_APP_ID }}
+          PAGES_WRITER_APP_PRIVATE_KEY: ${{ secrets.PAGES_WRITER_APP_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          test -n "$PAGES_WRITER_APP_ID"
+          test -n "$PAGES_WRITER_APP_PRIVATE_KEY"
+      - name: Mint the dedicated Pages writer token
+        id: pages-writer-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.PAGES_WRITER_APP_ID }}
+          private-key: ${{ secrets.PAGES_WRITER_APP_PRIVATE_KEY }}
+      - name: Write the canonical immutable snapshot
+        shell: bash
+        env:
+          PAGES_WRITER_TOKEN: ${{ steps.pages-writer-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          test -n "$PAGES_WRITER_TOKEN"
+          git -C pages push "https://x-access-token:${PAGES_WRITER_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD:gh-pages
+      - uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: written-pages
+          fetch-depth: 1
+          persist-credentials: false
+      - name: Read back the canonical commit and source manifest
+        shell: bash
+        env:
+          PUSHED_COMMIT: ${{ env.pushed_commit }}
+          REVISION: ${{ needs.validate-and-render.outputs.revision }}
+          VERSION: ${{ needs.validate-and-render.outputs.version }}
+          STATUS: ${{ needs.validate-and-render.outputs.status }}
+          SNAPSHOT_PATH: ${{ needs.validate-and-render.outputs.snapshot_path }}
+          RENDER_PATH: ${{ needs.validate-and-render.outputs.render_path }}
+        run: |
+          set -euo pipefail
+          test "$(git -C written-pages rev-parse HEAD)" = "$PUSHED_COMMIT"
+          staged_manifest="rendered/$RENDER_PATH/source-manifest.json"
+          written_manifest="written-pages/$SNAPSHOT_PATH/source-manifest.json"
+          test -f "$written_manifest"
+          cmp -- "$staged_manifest" "$written_manifest"
+          jq -e --arg revision "$REVISION" --arg version "$VERSION" --arg status "$STATUS" \
+            '.source.revision == $revision and .documentation.version == $version and .documentation.status == $status' \
+            "$written_manifest" >/dev/null

--- a/buildSrc/src/main/groovy/com/blackbuild/annodocimal/docs/VerifyVersionedDocumentationRendererTask.groovy
+++ b/buildSrc/src/main/groovy/com/blackbuild/annodocimal/docs/VerifyVersionedDocumentationRendererTask.groovy
@@ -187,10 +187,10 @@ abstract class VerifyVersionedDocumentationRendererTask extends DefaultTask {
         inputs.putAll(overrides)
         VersionedDocumentationRenderer.render(inputs)
     }
-    private static String branding(String identity, String season, String digest) {
+    private static String branding(String identity, String presentation, String digest) {
         """{
   \"identity\": \"$identity\",
-  \"season\": \"$season\",
+  \"presentation\": \"$presentation\",
   \"logo\": \"img/annodocimallogo.png\",
   \"altText\": \"AnnoDocimal logo\",
   \"sha256\": \"$digest\",

--- a/buildSrc/src/main/groovy/com/blackbuild/annodocimal/docs/VersionedDocumentationRenderer.groovy
+++ b/buildSrc/src/main/groovy/com/blackbuild/annodocimal/docs/VersionedDocumentationRenderer.groovy
@@ -184,7 +184,7 @@ class VersionedDocumentationRenderer {
                                                retainedPath: "rehearsal/${StaticDocumentationPageRenderer.CONTRACT_ID}/$revision"] :
                         [version: version, status: status] + (releaseStage ? [releaseStage: releaseStage] : [:]),
                 branding: branding == null ? null : [manifest: brandingManifestPath, identity: branding.identity,
-                                                     season: branding.season, altText: branding.altText,
+                                                     presentation: branding.presentation, altText: branding.altText,
                                                      approval: branding.approval, sourceAsset: branding.logo,
                                                      outputAsset: logoTarget, sha256: branding.sha256],
                 javadocs: hasApi ? javadocs.collectEntries { String module, File source -> [(module): sha256Directory(source)] } : [:],
@@ -281,7 +281,7 @@ class VersionedDocumentationRenderer {
         }
         if (!(parsed instanceof Map)) fail("Branding manifest must be an object: $path")
         Map<String, ?> branding = parsed as Map<String, ?>
-        ['identity', 'season', 'logo', 'altText', 'sha256', 'approval'].each { String field ->
+        ['identity', 'presentation', 'logo', 'altText', 'sha256', 'approval'].each { String field ->
             if (!(branding[field] instanceof String) || branding[field].trim().empty) fail("Branding manifest $path requires $field")
         }
         safePath(branding.logo)

--- a/docs/branding/annodocimal-current.json
+++ b/docs/branding/annodocimal-current.json
@@ -1,6 +1,6 @@
 {
   "identity": "AnnoDocimal",
-  "season": "Current identity",
+  "presentation": "Current identity",
   "logo": "img/annodocimallogo.png",
   "altText": "AnnoDocimal logo",
   "sha256": "4ed3b5202435de10abbb3e823884ca979a4915835de4c3d0eb0fdbc4bd60fc6f",

--- a/docs/publication-validation.md
+++ b/docs/publication-validation.md
@@ -69,3 +69,10 @@ local artifact is selected from `local-rehearsal/`; one or more maintainer-led p
 that artifact from a clearly experimental Pages branch. They record each validation in #71 and keep Pages unprotected
 until the first result is verified and accepted, after which Pages is deactivated and the branch is removed. They are not
 retained on the canonical Pages ledger.
+
+The canonical documentation writer is a separate `github-pages`-gated job, not part of render, crawl, publication
+smoke, or rehearsal. It requires the requested exact source to still be current `master`, validates the staged immutable
+manifest binding, and uses the dedicated environment-scoped Pages-writer App only for the `gh-pages` push. A remote
+read-back must confirm the pushed commit and manifest before the job succeeds. This is deployment integrity evidence;
+it neither authorizes a release nor changes #45's ordering, recovery, RC/final, tagging, signing, or release-record
+ownership.

--- a/docs/versioned-documentation.md
+++ b/docs/versioned-documentation.md
@@ -65,6 +65,8 @@ the protected canonical writer job. Public statuses additionally require the mat
 publication and therefore does not. Render and crawl jobs have only read permission and never receive the canonical
 writer App material.
 
+## Protected canonical writer
+
 The `github-pages` environment gates the distinct canonical writer job. Only that job may receive the environment-scoped
 dedicated Pages-writer App identifier and private key, and it mints that App's installation token only after the artifact
 has been staged. The workflow token remains read-only; the App token is used only for the `gh-pages` push. Before that
@@ -74,6 +76,10 @@ status. After the push, a fresh remote checkout must resolve to the pushed commi
 content with the same source/version/status binding. A missing protected-environment value fails the writer before token
 minting or canonical mutation. This workflow defines no App, secret, environment, Pages setting, branch rule, or
 `gh-pages` branch; those remain separate maintainer-controlled setup.
+
+The documentary contract
+`VersionedDocumentationDocumentaryTest.keeps the protected canonical writer separate from artifact-only rendering`
+checks this checked-in authority boundary while the release and rehearsal examples below prove rendering behavior.
 
 Before any authorized deployment, a maintainer must create `gh-pages`, configure Pages to serve it, and protect the
 `github-pages` environment. This repository configuration does not perform those remote actions.

--- a/docs/versioned-documentation.md
+++ b/docs/versioned-documentation.md
@@ -42,7 +42,7 @@ Historical releases live at `/archive/<version>/`. They are final-version snapsh
 may be rendered from README-only historic tags, may omit historical branding, and never receive current Javadocs.
 Ordinary immutable RC and final snapshots remain at `/<version>/`.
 
-Product renders require a versioned Season/logo manifest. A public RC or pending candidate may select a candidate
+Product renders require a versioned presentation/logo manifest. A public RC or pending candidate may select a candidate
 manifest. A current or pending final render must select `docs/branding/annodocimal-current.json`, whose logo digest is
 checked against the exact source commit. Issue #73 may replace it through an accepted future manifest, but retaining the
 current identity is valid and does not block an RC.

--- a/docs/versioned-documentation.md
+++ b/docs/versioned-documentation.md
@@ -61,8 +61,19 @@ release authorization, proof, metadata links, recovery, and supersession; this r
 authority.
 
 The release workflow defaults to artifact-only validation. It renders, crawls, and uploads the complete site but skips
-the protected deployment job. Public statuses additionally require the matching version tag; pending proof precedes
-publication and therefore does not. Repository write permission exists only inside the protected deployment job.
+the protected canonical writer job. Public statuses additionally require the matching version tag; pending proof precedes
+publication and therefore does not. Render and crawl jobs have only read permission and never receive the canonical
+writer App material.
+
+The `github-pages` environment gates the distinct canonical writer job. Only that job may receive the environment-scoped
+dedicated Pages-writer App identifier and private key, and it mints that App's installation token only after the artifact
+has been staged. The workflow token remains read-only; the App token is used only for the `gh-pages` push. Before that
+push, the writer resolves `refs/heads/master` remotely and refuses to continue unless its exact commit equals the
+requested source revision. It also verifies that the staged `source-manifest.json` binds that source, version, and
+status. After the push, a fresh remote checkout must resolve to the pushed commit and contain byte-identical manifest
+content with the same source/version/status binding. A missing protected-environment value fails the writer before token
+minting or canonical mutation. This workflow defines no App, secret, environment, Pages setting, branch rule, or
+`gh-pages` branch; those remain separate maintainer-controlled setup.
 
 Before any authorized deployment, a maintainer must create `gh-pages`, configure Pages to serve it, and protect the
 `github-pages` environment. This repository configuration does not perform those remote actions.
@@ -90,8 +101,9 @@ Inspect it in a browser under the real Pages base path with:
 The task prints a loopback `/anno-docimal/` URL and runs until interrupted.
 
 The separate presentation-rehearsal workflow is artifact-only. It renders and crawls the exact local tree, then uploads
-the result; it has no Pages write permission and no deployment input. It writes no version status, alias, release
-record, pending path, or Pages tree. Merging the workflow neither configures Pages nor dispatches it.
+the result; it has no Pages write permission, deployment input, protected environment, or Pages-writer App material. It
+writes no version status, alias, release record, pending path, or Pages tree. Merging the workflow neither configures
+Pages nor dispatches it.
 
 One or more maintainer-authorized platform rehearsals may use that generated artifact to populate a clearly experimental
 branch for manual Pages inspection. They are neither release evidence nor protected ledger entries: they use no `pending`

--- a/publication-smoke-tests/build.gradle
+++ b/publication-smoke-tests/build.gradle
@@ -10,6 +10,7 @@ java {
 
 dependencies {
     testImplementation libs.bundles.spock.groovy.v3
+    testImplementation libs.jb.anno
     testImplementation files(rootProject.file('buildSrc/build/libs/buildSrc.jar'))
     testImplementation 'org.commonmark:commonmark:0.28.0'
     testImplementation 'org.commonmark:commonmark-ext-gfm-tables:0.28.0'

--- a/publication-smoke-tests/build.gradle
+++ b/publication-smoke-tests/build.gradle
@@ -28,6 +28,7 @@ tasks.named('test') {
     systemProperty 'annodocimal.publication.version', project.version.toString()
     systemProperty 'annodocimal.maven.executable', rootProject.layout.buildDirectory
             .file("maven-distribution/apache-maven-${mavenVersion}/bin/mvn").get().asFile.absolutePath
+    systemProperty 'annodocimal.repository.root', rootProject.rootDir.absolutePath
 }
 
 def publicRcVersion = providers.gradleProperty('annodocimalVersion')

--- a/publication-smoke-tests/src/test/groovy/com/blackbuild/annodocimal/docs/VersionedDocumentationDocumentaryTest.groovy
+++ b/publication-smoke-tests/src/test/groovy/com/blackbuild/annodocimal/docs/VersionedDocumentationDocumentaryTest.groovy
@@ -25,6 +25,7 @@ package com.blackbuild.annodocimal.docs
 
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
+import org.intellij.lang.annotations.Language
 import org.commonmark.ext.gfm.tables.TablesExtension
 import org.commonmark.parser.Parser
 import spock.lang.Issue
@@ -99,7 +100,7 @@ class VersionedDocumentationDocumentaryTest extends Specification {
         new File(checkout, 'docs/branding').mkdirs()
         new File(checkout, 'docs/branding/annodocimal-current.json').text = """{
   \"identity\": \"AnnoDocimal\",
-  \"season\": \"Current identity\",
+  \"presentation\": \"Current identity\",
   \"logo\": \"img/annodocimallogo.png\",
   \"altText\": \"AnnoDocimal logo\",
   \"sha256\": \"${MessageDigest.getInstance('SHA-256').digest(logo).encodeHex()}\",
@@ -189,6 +190,7 @@ class VersionedDocumentationDocumentaryTest extends Specification {
         !new File(archiveOutput, 'archive/0.9.0/assets/branding').exists()
     }
 
+    @Language("groovy")
     private static String rehearsalBuild(File buildLogic, File commonmark, File tables, File javadocs, File localOutput) {
         String buildLogicPath = gradleString(buildLogic)
         String commonmarkPath = gradleString(commonmark)

--- a/publication-smoke-tests/src/test/groovy/com/blackbuild/annodocimal/docs/VersionedDocumentationDocumentaryTest.groovy
+++ b/publication-smoke-tests/src/test/groovy/com/blackbuild/annodocimal/docs/VersionedDocumentationDocumentaryTest.groovy
@@ -40,23 +40,35 @@ import java.security.MessageDigest
 @See('https://github.com/blackbuild/anno-docimal/blob/master/docs/versioned-documentation.md#local-presentation-rehearsal')
 class VersionedDocumentationDocumentaryTest extends Specification {
 
+    @See('https://github.com/blackbuild/anno-docimal/blob/master/docs/versioned-documentation.md#protected-canonical-writer')
     def 'keeps the protected canonical writer separate from artifact-only rendering'() {
         given: 'the checked-in Pages contracts'
         File repository = new File(System.getProperty('annodocimal.repository.root'))
         String publicationWorkflow = new File(repository, '.github/workflows/publish-versioned-documentation.yml').text
         String rehearsalWorkflow = new File(repository, '.github/workflows/rehearse-versioned-documentation.yml').text
         String documentation = new File(repository, 'docs/versioned-documentation.md').text
+        String writerJob = job(publicationWorkflow, 'write-canonical-immutable-snapshot')
+        String renderJob = job(publicationWorkflow, 'validate-and-render')
+        String ordinaryPublicationJobs = publicationWorkflow.replace(writerJob, '')
 
         expect: 'only the protected writer can mint the dedicated App token and use it to push canonical Pages'
-        publicationWorkflow.contains('write-canonical-immutable-snapshot:')
-        publicationWorkflow.contains('environment:\n      name: github-pages')
-        publicationWorkflow.contains('contents: read')
-        !publicationWorkflow.contains('contents: write')
-        publicationWorkflow.contains('actions/create-github-app-token@v1')
-        publicationWorkflow.contains('Require the requested source to be current master')
-        publicationWorkflow.contains('Assert the staged artifact is bound to the requested source')
-        publicationWorkflow.contains('Read back the canonical commit and source manifest')
-        publicationWorkflow.contains('HEAD:gh-pages')
+        writerJob.contains('environment:\n      name: github-pages')
+        writerJob.contains('contents: read')
+        !writerJob.contains('contents: write')
+        writerJob.contains('actions/create-github-app-token@v1')
+        writerJob.contains('PAGES_WRITER_APP_ID')
+        writerJob.contains('PAGES_WRITER_APP_PRIVATE_KEY')
+        writerJob.contains('Require the requested source to be current master')
+        writerJob.contains('Assert the staged artifact is bound to the requested source')
+        writerJob.contains('Read back the canonical commit and source manifest')
+        writerJob.contains('PAGES_WRITER_TOKEN')
+        writerJob.contains('HEAD:gh-pages')
+
+        and: 'rendering and all other ordinary workflow jobs cannot receive or mint writer credentials'
+        !renderJob.contains('PAGES_WRITER_')
+        !renderJob.contains('create-github-app-token')
+        !ordinaryPublicationJobs.contains('PAGES_WRITER_')
+        !ordinaryPublicationJobs.contains('create-github-app-token')
 
         and: 'the disposable rehearsal remains credential-free and artifact-only'
         !rehearsalWorkflow.contains('github-pages')
@@ -240,6 +252,12 @@ tasks.register('renderVersionedDocumentation', RenderVersionedDocumentationTask)
 
     private static String gradleString(File file) {
         file.absolutePath.replace('\\', '\\\\').replace("'", "\\'")
+    }
+
+    private static String job(String workflow, String name) {
+        def match = (workflow =~ "(?ms)^  ${name}:\\n(.*?)(?=^  [A-Za-z][A-Za-z0-9-]*:\\n|\\z)")
+        assert match.find(): "Missing workflow job: $name"
+        match.group(0)
     }
 
     private static String git(File directory, List<String> arguments) {

--- a/publication-smoke-tests/src/test/groovy/com/blackbuild/annodocimal/docs/VersionedDocumentationDocumentaryTest.groovy
+++ b/publication-smoke-tests/src/test/groovy/com/blackbuild/annodocimal/docs/VersionedDocumentationDocumentaryTest.groovy
@@ -40,6 +40,34 @@ import java.security.MessageDigest
 @See('https://github.com/blackbuild/anno-docimal/blob/master/docs/versioned-documentation.md#local-presentation-rehearsal')
 class VersionedDocumentationDocumentaryTest extends Specification {
 
+    def 'keeps the protected canonical writer separate from artifact-only rendering'() {
+        given: 'the checked-in Pages contracts'
+        File repository = new File(System.getProperty('annodocimal.repository.root'))
+        String publicationWorkflow = new File(repository, '.github/workflows/publish-versioned-documentation.yml').text
+        String rehearsalWorkflow = new File(repository, '.github/workflows/rehearse-versioned-documentation.yml').text
+        String documentation = new File(repository, 'docs/versioned-documentation.md').text
+
+        expect: 'only the protected writer can mint the dedicated App token and use it to push canonical Pages'
+        publicationWorkflow.contains('write-canonical-immutable-snapshot:')
+        publicationWorkflow.contains('environment:\n      name: github-pages')
+        publicationWorkflow.contains('contents: read')
+        !publicationWorkflow.contains('contents: write')
+        publicationWorkflow.contains('actions/create-github-app-token@v1')
+        publicationWorkflow.contains('Require the requested source to be current master')
+        publicationWorkflow.contains('Assert the staged artifact is bound to the requested source')
+        publicationWorkflow.contains('Read back the canonical commit and source manifest')
+        publicationWorkflow.contains('HEAD:gh-pages')
+
+        and: 'the disposable rehearsal remains credential-free and artifact-only'
+        !rehearsalWorkflow.contains('github-pages')
+        !rehearsalWorkflow.contains('create-github-app-token')
+        !rehearsalWorkflow.contains('gh-pages')
+
+        and: 'the maintainer documentation makes the authority boundary auditable'
+        documentation.contains('protected canonical writer job')
+        documentation.contains('Pages-writer App')
+    }
+
     def 'demonstrates an immutable exact-site rehearsal'() {
         given: 'a clean checkout at one exact commit and generated module Javadocs'
         File checkout = Files.createTempDirectory('documentation-checkout-').toFile()


### PR DESCRIPTION
## Summary

- separate the protected canonical Pages writer from credential-free render/crawl and disposable rehearsal paths
- mint the dedicated environment-scoped GitHub App token only inside the protected writer; retain read-only workflow-token permissions
- require the requested source to equal current `master`, bind the staged manifest to source/version/status, and read back the pushed commit and manifest
- document the authority boundary, retain #45 release ownership, and replace Klum-specific branding `season` metadata with neutral `presentation`

## Validation

- `./gradlew check`
- `./gradlew verifyVersionedDocumentationRenderer :publication-smoke-tests:test --tests com.blackbuild.annodocimal.docs.VersionedDocumentationDocumentaryTest`
- Ruby YAML parse of the publishing and rehearsal workflows
- `git diff --check origin/master...HEAD`
- Standards and Spec review; both findings addressed in follow-up commits

## Security review focus

Review App material and token confinement to `write-canonical-immutable-snapshot`, the current-`master` assertion before the canonical write, staged/remote manifest verification, and rehearsal's absence of protected credentials or `gh-pages` writes.

No GitHub App, environment, Pages, branch, ruleset, secret, release, tag, or workflow dispatch was configured or performed.

Related: #71
