### PR TITLE
Separate protected Pages writer environment (#71)

### DIFF
--- a/.github/workflows/publish-versioned-documentation.yml
+++ b/.github/workflows/publish-versioned-documentation.yml
@@ -158,7 +158,7 @@ jobs:
     needs: validate-and-render
     runs-on: ubuntu-latest
     environment:
-      name: github-pages
+      name: annodocimal-pages-writer
     permissions:
       contents: read
     steps:

--- a/docs/publication-validation.md
+++ b/docs/publication-validation.md
@@ -70,9 +70,11 @@ that artifact from a clearly experimental Pages branch. They record each validat
 until the first result is verified and accepted, after which Pages is deactivated and the branch is removed. They are not
 retained on the canonical Pages ledger.
 
-The canonical documentation writer is a separate `github-pages`-gated job, not part of render, crawl, publication
-smoke, or rehearsal. It requires the requested exact source to still be current `master`, validates the staged immutable
-manifest binding, and uses the dedicated environment-scoped Pages-writer App only for the `gh-pages` push. A remote
-read-back must confirm the pushed commit and manifest before the job succeeds. This is deployment integrity evidence;
-it neither authorizes a release nor changes #45's ordering, recovery, RC/final, tagging, signing, or release-record
-ownership.
+The canonical documentation writer is a separate, master-only, reviewed
+`annodocimal-pages-writer`-gated job, not part of render, crawl, publication smoke, or rehearsal. It requires the
+requested exact source to still be current `master`, validates the staged immutable manifest binding, and uses the
+dedicated environment-scoped Pages-writer App only for the `gh-pages` push. A remote read-back must confirm the pushed
+commit and manifest before the job succeeds. The separate `github-pages` environment is the credential-free GitHub
+Pages service deployment from the protected `gh-pages` branch; it never receives or mints the App token. This is
+deployment integrity evidence; it neither authorizes a release nor changes #45's ordering, recovery, RC/final, tagging,
+signing, or release-record ownership.

--- a/docs/versioned-documentation.md
+++ b/docs/versioned-documentation.md
@@ -67,22 +67,31 @@ writer App material.
 
 ## Protected canonical writer
 
-The `github-pages` environment gates the distinct canonical writer job. Only that job may receive the environment-scoped
-dedicated Pages-writer App identifier and private key, and it mints that App's installation token only after the artifact
-has been staged. The workflow token remains read-only; the App token is used only for the `gh-pages` push. Before that
-push, the writer resolves `refs/heads/master` remotely and refuses to continue unless its exact commit equals the
-requested source revision. It also verifies that the staged `source-manifest.json` binds that source, version, and
-status. After the push, a fresh remote checkout must resolve to the pushed commit and contain byte-identical manifest
-content with the same source/version/status binding. A missing protected-environment value fails the writer before token
-minting or canonical mutation. This workflow defines no App, secret, environment, Pages setting, branch rule, or
-`gh-pages` branch; those remain separate maintainer-controlled setup.
+The credential-bearing `annodocimal-pages-writer` environment gates the distinct canonical writer job. Only that
+master-only, reviewed job may receive the environment-scoped dedicated Pages-writer App identifier and private key, and
+it mints that App's installation token only after the artifact has been staged. The workflow token remains read-only;
+the App token is used only for the `gh-pages` push. Before that push, the writer resolves `refs/heads/master` remotely
+and refuses to continue unless its exact commit equals the requested source revision. It also verifies that the staged
+`source-manifest.json` binds that source, version, and status. After the push, a fresh remote checkout must resolve to
+the pushed commit and contain byte-identical manifest content with the same source/version/status binding. A missing
+protected-environment value fails the writer before token minting or canonical mutation.
+
+The separately named `github-pages` environment is the credential-free GitHub Pages service deployment from the
+protected `gh-pages` branch. It receives neither the Pages-writer App material nor its installation token and is not a
+canonical-writer approval boundary. This workflow writes the protected ledger only through
+`annodocimal-pages-writer`; GitHub Pages serves the resulting commit through its distinct service deployment boundary.
+
+This workflow defines no App, secret, environment, Pages setting, branch rule, or `gh-pages` branch; those remain
+separate maintainer-controlled setup.
 
 The documentary contract
 `VersionedDocumentationDocumentaryTest.keeps the protected canonical writer separate from artifact-only rendering`
 checks this checked-in authority boundary while the release and rehearsal examples below prove rendering behavior.
 
-Before any authorized deployment, a maintainer must create `gh-pages`, configure Pages to serve it, and protect the
-`github-pages` environment. This repository configuration does not perform those remote actions.
+Before any authorized deployment, a maintainer must create and protect `gh-pages`, configure Pages to serve that
+branch through the credential-free `github-pages` environment, and protect the separate
+`annodocimal-pages-writer` environment for the canonical writer. This repository configuration does not perform those
+remote actions.
 
 ## Local presentation rehearsal
 

--- a/publication-smoke-tests/src/test/groovy/com/blackbuild/annodocimal/docs/VersionedDocumentationDocumentaryTest.groovy
+++ b/publication-smoke-tests/src/test/groovy/com/blackbuild/annodocimal/docs/VersionedDocumentationDocumentaryTest.groovy
@@ -52,8 +52,9 @@ class VersionedDocumentationDocumentaryTest extends Specification {
         String renderJob = job(publicationWorkflow, 'validate-and-render')
         String ordinaryPublicationJobs = publicationWorkflow.replace(writerJob, '')
 
-        expect: 'only the protected writer can mint the dedicated App token and use it to push canonical Pages'
-        writerJob.contains('environment:\n      name: github-pages')
+        expect: 'only the protected writer environment can mint the dedicated App token and use it to push canonical Pages'
+        writerJob.contains('environment:\n      name: annodocimal-pages-writer')
+        !writerJob.contains('environment:\n      name: github-pages')
         writerJob.contains('contents: read')
         !writerJob.contains('contents: write')
         writerJob.contains('actions/create-github-app-token@v1')
@@ -70,6 +71,7 @@ class VersionedDocumentationDocumentaryTest extends Specification {
         !renderJob.contains('create-github-app-token')
         !ordinaryPublicationJobs.contains('PAGES_WRITER_')
         !ordinaryPublicationJobs.contains('create-github-app-token')
+        !publicationWorkflow.contains('environment:\n      name: github-pages')
 
         and: 'the disposable rehearsal remains credential-free and artifact-only'
         !rehearsalWorkflow.contains('github-pages')
@@ -77,6 +79,10 @@ class VersionedDocumentationDocumentaryTest extends Specification {
         !rehearsalWorkflow.contains('gh-pages')
 
         and: 'the maintainer documentation makes the authority boundary auditable'
+        documentation.contains('`annodocimal-pages-writer` environment')
+        documentation.contains('`github-pages` environment')
+        documentation.contains('credential-free GitHub Pages service deployment')
+        documentation.contains('protected `gh-pages` branch')
         documentation.contains('protected canonical writer job')
         documentation.contains('Pages-writer App')
     }


### PR DESCRIPTION
## Summary

- move the canonical immutable snapshot writer to the protected `annodocimal-pages-writer` environment
- document the distinct, credential-free `github-pages` service deployment from the protected `gh-pages` branch
- extend the documentary contract to enforce token confinement and the two-boundary model

The writer retains its current-master assertion, immutable snapshot checks, and post-push remote read-back. The change does not configure remote environments, Pages, or branch protection.

Related: #71

## Validation

- `./gradlew :publication-smoke-tests:test --tests com.blackbuild.annodocimal.docs.VersionedDocumentationDocumentaryTest`
- YAML parsing for `.github/workflows/publish-versioned-documentation.yml`
- `git diff --check`
- `./gradlew check`

## Review focus

Confirm the remote configuration applies the documented two-environment boundary: only `annodocimal-pages-writer` may expose the App credentials, while `github-pages` remains the credential-free Pages service deployment.
