### PR TITLE
Align versioned documentation routing

### DIFF
--- a/.github/workflows/publish-versioned-documentation.yml
+++ b/.github/workflows/publish-versioned-documentation.yml
@@ -29,6 +29,10 @@ on:
         description: Exact RC version superseded by this final release, after release proof
         required: false
         type: string
+      alias_proof:
+        description: HTTPS reference to #45-recorded public-artifact proof; required before a public route advances an alias
+        required: false
+        type: string
       deploy:
         description: Publish the validated artifact after protected-environment approval
         required: true
@@ -56,21 +60,27 @@ jobs:
           STATUS: ${{ inputs.status }}
           RELEASE_STAGE: ${{ inputs.release_stage }}
           SUCCESSOR_OF: ${{ inputs.successor_of }}
+          ALIAS_PROOF: ${{ inputs.alias_proof }}
+          DEPLOY: ${{ inputs.deploy }}
         run: |
           [[ "$REVISION" =~ ^[0-9a-f]{40}$ ]]
           [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[1-9][0-9]*)?$ ]]
+          [[ "$DEPLOY" == true || "$DEPLOY" == false ]]
           case "$STATUS" in
             pending)
+              [[ -z "$ALIAS_PROOF" ]]
               [[ "$RELEASE_STAGE" == candidate || "$RELEASE_STAGE" == final ]]
               if [[ "$RELEASE_STAGE" == candidate ]]; then [[ "$VERSION" == *-rc.* ]]; else [[ "$VERSION" != *-rc.* ]]; fi
               ;;
             public-rc)
               [[ -z "$RELEASE_STAGE" ]]
               [[ "$VERSION" == *-rc.* ]]
+              if [[ "$DEPLOY" == true ]]; then [[ "$ALIAS_PROOF" =~ ^https://[^[:space:]]+$ ]]; else [[ -z "$ALIAS_PROOF" ]]; fi
               ;;
             current|archived)
               [[ -z "$RELEASE_STAGE" ]]
               [[ "$VERSION" != *-rc.* ]]
+              if [[ "$STATUS" == current && "$DEPLOY" == true ]]; then [[ "$ALIAS_PROOF" =~ ^https://[^[:space:]]+$ ]]; else [[ -z "$ALIAS_PROOF" ]]; fi
               ;;
             *) exit 1 ;;
           esac
@@ -84,9 +94,6 @@ jobs:
           if [[ "$STATUS" == pending ]]; then
             echo "render_path=$VERSION" >> "$GITHUB_OUTPUT"
             echo "snapshot_path=pending/$VERSION/$REVISION" >> "$GITHUB_OUTPUT"
-          elif [[ "$STATUS" == archived ]]; then
-            echo "render_path=archive/$VERSION" >> "$GITHUB_OUTPUT"
-            echo "snapshot_path=archive/$VERSION" >> "$GITHUB_OUTPUT"
           else
             echo "render_path=$VERSION" >> "$GITHUB_OUTPUT"
             echo "snapshot_path=$VERSION" >> "$GITHUB_OUTPUT"
@@ -212,6 +219,50 @@ jobs:
           touch pages/.nojekyll
           mkdir -p "pages/$(dirname "$SNAPSHOT_PATH")"
           mv "rendered/$RENDER_PATH" "pages/$SNAPSHOT_PATH"
+
+          write_alias() {
+            local alias="$1"
+            local target="$2"
+            local label="$3"
+            local explanation="$4"
+            mkdir -p "pages/$alias"
+            {
+              printf '%s\n' '<!doctype html>' '<html lang="en"><head><meta charset="utf-8">'
+              printf '<meta http-equiv="refresh" content="0; url=/anno-docimal/%s/">\n' "$target"
+              printf '<title>%s</title></head><body><h1>%s</h1>\n' "$label" "$label"
+              printf '<p>%s <a href="/anno-docimal/%s/">Open immutable documentation %s</a>.</p>\n' "$explanation" "$target" "$target"
+              printf '%s\n' '</body></html>'
+            } > "pages/$alias/index.html"
+          }
+
+          case "$STATUS" in
+            public-rc)
+              write_alias preview "$VERSION" 'Preview documentation (proof-gated)' 'This alias names one publicly proven release candidate.'
+              ;;
+            current)
+              maintained_line="${VERSION%.*}"
+              write_alias stable "$VERSION" 'Stable documentation (proof-gated)' 'This alias names one publicly proven final release.'
+              write_alias "$maintained_line" "$VERSION" "Maintained $maintained_line documentation (proof-gated)" 'This alias names the publicly proven final release for its maintained line.'
+              ;;
+            archived)
+              mkdir -p pages/archive
+              {
+                printf '%s\n' '<!doctype html>' '<html lang="en"><head><meta charset="utf-8"><title>Documentation archive</title></head><body>'
+                printf '%s\n' '<h1>Documentation archive</h1><p>Historical snapshots remain at their immutable version routes.</p><ul>'
+                while IFS= read -r archived_version; do
+                  printf '<li><a href="/anno-docimal/%s/">%s</a></li>\n' "$archived_version" "$archived_version"
+                done < <(
+                  for manifest in pages/*/source-manifest.json; do
+                    [[ -f "$manifest" ]] || continue
+                    if [[ "$(jq -r '.documentation.status' "$manifest")" == archived ]]; then
+                      jq -r '.documentation.version' "$manifest"
+                    fi
+                  done | sort -V
+                )
+                printf '%s\n' '</ul></body></html>'
+              } > pages/archive/index.html
+              ;;
+          esac
           if [[ "$STATUS" != pending ]]; then
             mkdir -p pages/status
             cp -R rendered/status/. pages/status/
@@ -221,6 +272,9 @@ jobs:
           git -C pages add "$SNAPSHOT_PATH"
           git -C pages add .nojekyll
           if [[ "$STATUS" != pending ]]; then git -C pages add status; fi
+          if [[ "$STATUS" == public-rc ]]; then git -C pages add preview; fi
+          if [[ "$STATUS" == current ]]; then git -C pages add stable "$maintained_line"; fi
+          if [[ "$STATUS" == archived ]]; then git -C pages add archive; fi
           git -C pages commit -m "Publish immutable documentation snapshot $SNAPSHOT_PATH"
           echo "pushed_commit=$(git -C pages rev-parse HEAD)" >> "$GITHUB_ENV"
       - name: Require protected writer credentials

--- a/.github/workflows/publish-versioned-documentation.yml
+++ b/.github/workflows/publish-versioned-documentation.yml
@@ -177,11 +177,17 @@ jobs:
         shell: bash
         env:
           REVISION: ${{ needs.validate-and-render.outputs.revision }}
+          VERSION: ${{ needs.validate-and-render.outputs.version }}
+          STATUS: ${{ needs.validate-and-render.outputs.status }}
         run: |
           set -euo pipefail
           test "$(git rev-parse "$REVISION^{commit}")" = "$REVISION"
-          master_revision="$(git ls-remote --exit-code origin refs/heads/master | awk '{print $1}')"
-          test "$master_revision" = "$REVISION"
+          if [[ "$STATUS" == archived ]]; then
+            test "$(git tag --points-at "$REVISION" "v$VERSION")" = "v$VERSION"
+          else
+            master_revision="$(git ls-remote --exit-code origin refs/heads/master | awk '{print $1}')"
+            test "$master_revision" = "$REVISION"
+          fi
       - uses: actions/download-artifact@v4
         with:
           name: versioned-documentation

--- a/.github/workflows/publish-versioned-documentation.yml
+++ b/.github/workflows/publish-versioned-documentation.yml
@@ -30,7 +30,7 @@ on:
         required: false
         type: string
       alias_proof:
-        description: HTTPS reference to #45-recorded public-artifact proof; required before a public route advances an alias
+        description: "HTTPS reference to #45-recorded public-artifact proof; required before a public route advances an alias"
         required: false
         type: string
       deploy:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,9 @@
 
 - Added a protected, immutable GitHub Pages publication seam for deterministic static HTML and all supported Java API
   Javadocs. Pull requests render and crawl a distinct non-release rehearsal without deployment; exact release manifests
-  cover the deployed HTML, assets, and Javadoc bytes. Release authorization and recovery remain in the #45 runbook. See
+  cover the deployed HTML, assets, and Javadoc bytes. Immutable RC, final, and historical snapshots all use their exact
+  version route; the archive is a discovery index, and labelled stable, maintained-line, and preview aliases require
+  #45-recorded public-artifact proof. Release authorization and recovery remain in the #45 runbook. See
   repository-owned versioned documentation.
 
 - Added shared Java APT, local Groovy, and packaged global-AST capture conformance evidence across Groovy 3, 4, and 5.

--- a/build.gradle
+++ b/build.gradle
@@ -108,8 +108,7 @@ tasks.register('verifyVersionedDocumentationRenderer', VerifyVersionedDocumentat
 }
 
 def renderedDocumentationEntryPath = providers.provider {
-    documentationStatus.get() == 'archived' ? "archive/${providers.gradleProperty('documentationVersion').get()}" :
-            providers.gradleProperty('documentationVersion').get()
+    providers.gradleProperty('documentationVersion').get()
 }
 tasks.register('verifyRenderedVersionedDocumentationSite', VerifyRenderedDocumentationSiteTask) {
     group = 'verification'

--- a/buildSrc/src/main/groovy/com/blackbuild/annodocimal/docs/VerifyVersionedDocumentationRendererTask.groovy
+++ b/buildSrc/src/main/groovy/com/blackbuild/annodocimal/docs/VerifyVersionedDocumentationRendererTask.groovy
@@ -103,11 +103,12 @@ abstract class VerifyVersionedDocumentationRendererTask extends DefaultTask {
         render(fixture, archive, historicRevision, javadoc,
                 [version: '0.9.0', status: 'archived', javadocInputDirectories: [:],
                  brandingManifestPath: null, currentBrandingManifestPath: null])
-        assertTrue(new File(archive, 'archive/0.9.0/index.html').text.contains('Archived (legacy)'), 'legacy archive chrome')
-        assertTrue(!new File(archive, 'archive/0.9.0/docs').exists(), 'README-only archives do not require modern Markdown sources')
-        assertTrue(!new File(archive, 'archive/0.9.0/CHANGES').exists(), 'README-only archives do not require modern change history')
-        assertTrue(!new File(archive, 'archive/0.9.0/api').exists(), 'archives do not fabricate current Javadocs')
-        verifySite(archive, 'archive/0.9.0')
+        assertTrue(new File(archive, '0.9.0/index.html').text.contains('Archived (legacy)'), 'legacy archive chrome')
+        assertTrue(!new File(archive, 'archive').exists(), 'the renderer reserves /archive/ for writer-owned discovery')
+        assertTrue(!new File(archive, '0.9.0/docs').exists(), 'README-only archives do not require modern Markdown sources')
+        assertTrue(!new File(archive, '0.9.0/CHANGES').exists(), 'README-only archives do not require modern change history')
+        assertTrue(!new File(archive, '0.9.0/api').exists(), 'archives do not fabricate current Javadocs')
+        verifySite(archive, '0.9.0')
         File finalRelease = new File(temporaryDir, 'final-release')
         project.delete(finalRelease)
         render(fixture, finalRelease, revision, javadoc,

--- a/buildSrc/src/main/groovy/com/blackbuild/annodocimal/docs/VersionedDocumentationRenderer.groovy
+++ b/buildSrc/src/main/groovy/com/blackbuild/annodocimal/docs/VersionedDocumentationRenderer.groovy
@@ -86,7 +86,7 @@ class VersionedDocumentationRenderer {
         if (outputDirectory.exists() && outputDirectory.listFiles()?.length)
             fail("Output directory must be empty so an immutable snapshot cannot be overwritten: $outputDirectory")
         outputDirectory.mkdirs()
-        String snapshotPath = status == 'archived' ? "archive/$version" : version
+        String snapshotPath = version
         File exactDirectory = new File(outputDirectory, snapshotPath)
 
         Map<String, byte[]> authoredMarkdown = new TreeMap<>()

--- a/docs/adr/0060-render-versioned-documentation-as-static-html.md
+++ b/docs/adr/0060-render-versioned-documentation-as-static-html.md
@@ -7,3 +7,9 @@ exact-tree landing. The repository README and change history are not renderer in
 link rewriting, manifests, and credential-free crawling, while a distinct non-release rehearsal path proves presentation
 without consuming single-use pending release evidence. The shared contract standardizes outcomes, not code or release
 mechanics, so AnnoDocimal retains its repository-local implementation and protected publication ownership.
+
+The public topology is also part of the presentation contract: every immutable RC, final, and historical snapshot uses
+`/<version>/`; `/archive/` is a mutable discovery index only. Labelled `/preview/`, `/stable/`, and
+`/<maintained-line>/` aliases are writer-owned and proof-gated, while unlisted pending evidence remains single-use at
+`/pending/<version>/<full-source-sha>/`. This decision does not make aliases release authority: #45 supplies the
+public-artifact proof and retains ordering, recovery, and supersession ownership.

--- a/docs/publication-validation.md
+++ b/docs/publication-validation.md
@@ -79,6 +79,10 @@ Pages service deployment from the protected `gh-pages` branch; it never receives
 deployment integrity evidence; it neither authorizes a release nor changes #45's ordering, recovery, RC/final, tagging,
 signing, or release-record ownership.
 
+The sole source-selection exception is an `archived` render from its exact `v<version>` tag. It remains protected by the
+same App-only writer, immutable-path absence check, manifest binding, and remote read-back; it exists only so historical
+documentation can occupy its required `/<version>/` route and appear in the `/archive/` discovery index.
+
 Public routing preserves every RC, final, and historical snapshot at `/<version>/`; `/archive/` is only the historical
 discovery index. The protected writer may advance labelled `/preview/`, `/stable/`, or `/<maintained-line>/` aliases only
 when its `deploy=true` dispatch supplies the HTTPS #45-recorded public-artifact proof reference. Pending evidence rejects that input,

--- a/docs/publication-validation.md
+++ b/docs/publication-validation.md
@@ -78,3 +78,8 @@ commit and manifest before the job succeeds. The separate `github-pages` environ
 Pages service deployment from the protected `gh-pages` branch; it never receives or mints the App token. This is
 deployment integrity evidence; it neither authorizes a release nor changes #45's ordering, recovery, RC/final, tagging,
 signing, or release-record ownership.
+
+Public routing preserves every RC, final, and historical snapshot at `/<version>/`; `/archive/` is only the historical
+discovery index. The protected writer may advance labelled `/preview/`, `/stable/`, or `/<maintained-line>/` aliases only
+when its `deploy=true` dispatch supplies the HTTPS #45-recorded public-artifact proof reference. Pending evidence rejects that input,
+stays at `pending/<version>/<full-source-sha>/`, and advances neither aliases nor public status.

--- a/docs/versioned-documentation.md
+++ b/docs/versioned-documentation.md
@@ -35,12 +35,21 @@ that superseded the RC, but the RC tree and its manifest are never changed. A su
 final render with an explicit exact RC predecessor; #45 must provide release proof before requesting that update.
 
 Pending evidence is immutable, deployed-but-unlisted pre-publication proof. The protected workflow places it at
-`/pending/<version>/<revision>/`; it creates no public root status record and advances no public, stable, or line alias.
+`/pending/<version>/<full-source-sha>/`; it creates no public root status record and advances no public, stable, or line alias.
 It is not a public RC or final-release claim, and its path is single-use release evidence rather than a disposable test.
 
-Historical releases live at `/archive/<version>/`. They are final-version snapshots with `Archived (legacy)` chrome,
-may be rendered from README-only historic tags, may omit historical branding, and never receive current Javadocs.
-Ordinary immutable RC and final snapshots remain at `/<version>/`.
+Every immutable public RC, final, and historical snapshot lives at `/<version>/`. Historical snapshots use
+`Archived (legacy)` chrome, may be rendered from README-only historic tags, may omit historical branding, and never
+receive current Javadocs. `/archive/` is a discovery index owned by the writer that links to those immutable version routes;
+it is never a historical snapshot prefix.
+
+`/stable/`, `/<maintained-line>/`, and `/preview/` are labelled, mutable proof-gated aliases. `preview` names one
+publicly proven RC; `stable` names one publicly proven final snapshot; and the maintained-line alias (for example,
+`/1.0/`) names the publicly proven final snapshot for that line. There is no moving development site. The protected
+writer advances `preview` only for `public-rc` and `stable` plus the exact major/minor alias only for `current`, after
+a `deploy=true` dispatch supplies an HTTPS reference to #45-recorded public-artifact proof. Artifact-only validation
+uses `deploy=false`, accepts no proof input, and advances no alias. `pending` and `archived` reject that proof input and
+cannot advance an alias.
 
 Product renders require a versioned presentation/logo manifest. A public RC or pending candidate may select a candidate
 manifest. A current or pending final render must select `docs/branding/annodocimal-current.json`, whose logo digest is
@@ -53,12 +62,12 @@ collisions, and non-empty output directories. The mandatory JDK-only presentatio
 real `/anno-docimal/` Pages base path and crawls the renderer-owned output selector, exact-tree landing, every local page
 and asset, Javadocs, and fragments. Markdown URLs, missing targets, missing anchors, and base-path escapes fail the check.
 
-The protected release deployment adds exactly one previously absent `/<version>/`,
-`/pending/<version>/<revision>/`, or `/archive/<version>/` tree to `gh-pages`. Pending evidence does not touch root
-`status/`. A public deployment may update only those root status records, never a snapshot or manifest, and creates no
-mutable development, stable, or preview alias. [Issue #45](https://github.com/blackbuild/anno-docimal/issues/45) owns
-release authorization, proof, metadata links, recovery, and supersession; this renderer has no artifact-publication
-authority.
+The protected release deployment adds exactly one previously absent `/<version>/` or
+`/pending/<version>/<full-source-sha>/` tree to `gh-pages`. Pending evidence does not touch root `status/`. A public deployment
+may update only root status records and its explicitly proof-gated alias pages, never a snapshot or manifest. An archived
+deployment may additionally regenerate only the `/archive/` discovery index. [Issue #45](https://github.com/blackbuild/anno-docimal/issues/45)
+owns release authorization, public-artifact proof, metadata links, recovery, and supersession; this renderer has no
+artifact-publication authority.
 
 The release workflow defaults to artifact-only validation. It renders, crawls, and uploads the complete site but skips
 the protected canonical writer job. Public statuses additionally require the matching version tag; pending proof precedes
@@ -150,10 +159,12 @@ This compiles all six module Javadocs and produces a local selector plus static 
 selector. The documentary happy path is
 `VersionedDocumentationDocumentaryTest.demonstrates an immutable exact-site rehearsal`.
 
-An archive render instead uses `-PdocumentationStatus=archived`. A final successor update additionally uses
+An archive render instead uses `-PdocumentationStatus=archived`; its exact tree is still
+`build/versioned-documentation/<version>/`, while the protected writer later updates `/archive/` as a discovery index.
+A final successor update additionally uses
 `-PdocumentationSuccessorOf=1.0.0-rc.1`, `-PdocumentationVersion=1.0.0`, and `-PdocumentationStatus=current`; it
 produces `status/1.0.0-rc.1.json` without writing inside the prior RC snapshot.
 
 A pending candidate proof uses `-PdocumentationStatus=pending` and `-PdocumentationReleaseStage=candidate`. Its local
 artifact remains under `<output>/1.0.0-rc.1/`; only the protected deployment seam maps it to the single-use
-`/pending/1.0.0-rc.1/<revision>/` evidence path.
+`/pending/1.0.0-rc.1/<full-source-sha>/` evidence path.

--- a/docs/versioned-documentation.md
+++ b/docs/versioned-documentation.md
@@ -51,6 +51,9 @@ a `deploy=true` dispatch supplies an HTTPS reference to #45-recorded public-arti
 uses `deploy=false`, accepts no proof input, and advances no alias. `pending` and `archived` reject that proof input and
 cannot advance an alias.
 
+The executable routing contract is
+`VersionedDocumentationDocumentaryTest.keeps public documentation routing immutable and proof-gated`.
+
 Product renders require a versioned presentation/logo manifest. A public RC or pending candidate may select a candidate
 manifest. A current or pending final render must select `docs/branding/annodocimal-current.json`, whose logo digest is
 checked against the exact source commit. Issue #73 may replace it through an accepted future manifest, but retaining the
@@ -77,10 +80,12 @@ writer App material.
 ## Protected canonical writer
 
 The credential-bearing `annodocimal-pages-writer` environment gates the distinct canonical writer job. Only that
-master-only, reviewed job may receive the environment-scoped dedicated Pages-writer App identifier and private key, and
-it mints that App's installation token only after the artifact has been staged. The workflow token remains read-only;
-the App token is used only for the `gh-pages` push. Before that push, the writer resolves `refs/heads/master` remotely
-and refuses to continue unless its exact commit equals the requested source revision. It also verifies that the staged
+reviewed job may receive the environment-scoped dedicated Pages-writer App identifier and private key, and it mints that
+App's installation token only after the artifact has been staged. The workflow token remains read-only; the App token is
+used only for the `gh-pages` push. Before that push, the writer resolves `refs/heads/master` remotely and refuses to
+continue unless a pending, public-RC, or current source revision is its exact tip. The narrow archived exception accepts
+only an exact tagged historical source (`v<version>`), so a legacy snapshot can be published at its immutable version
+route and added to `/archive/` without weakening the non-archive master boundary. It also verifies that the staged
 `source-manifest.json` binds that source, version, and status. After the push, a fresh remote checkout must resolve to
 the pushed commit and contain byte-identical manifest content with the same source/version/status binding. A missing
 protected-environment value fails the writer before token minting or canonical mutation.

--- a/publication-smoke-tests/src/test/groovy/com/blackbuild/annodocimal/docs/VersionedDocumentationDocumentaryTest.groovy
+++ b/publication-smoke-tests/src/test/groovy/com/blackbuild/annodocimal/docs/VersionedDocumentationDocumentaryTest.groovy
@@ -85,6 +85,21 @@ class VersionedDocumentationDocumentaryTest extends Specification {
         documentation.contains('protected `gh-pages` branch')
         documentation.contains('protected canonical writer job')
         documentation.contains('Pages-writer App')
+
+        and: 'public routing keeps every snapshot exact and advances only explicitly proof-gated aliases'
+        publicationWorkflow.contains('alias_proof:')
+        publicationWorkflow.contains('DEPLOY: ${{ inputs.deploy }}')
+        publicationWorkflow.contains('[[ "$ALIAS_PROOF" =~ ^https://[^[:space:]]+$ ]]')
+        publicationWorkflow.contains('[[ -z "$ALIAS_PROOF" ]]')
+        !publicationWorkflow.contains('snapshot_path=archive/$VERSION')
+        writerJob.contains("write_alias preview \"\$VERSION\" 'Preview documentation (proof-gated)'")
+        writerJob.contains("write_alias stable \"\$VERSION\" 'Stable documentation (proof-gated)'")
+        writerJob.contains('maintained_line="${VERSION%.*}"')
+        writerJob.contains('pages/archive/index.html')
+        writerJob.contains('pages/*/source-manifest.json')
+        documentation.contains('`/archive/` is a discovery index')
+        documentation.contains('`/stable/`, `/<maintained-line>/`, and `/preview/`')
+        documentation.contains('`/pending/<version>/<full-source-sha>/`')
     }
 
     def 'demonstrates an immutable exact-site rehearsal'() {
@@ -189,11 +204,12 @@ class VersionedDocumentationDocumentaryTest extends Specification {
                         "-PdocumentationOutputDirectory=${archiveOutput.absolutePath}")
                 .build()
 
-        then: 'the Gradle seam preserves the explicit legacy archive contract'
+        then: 'the Gradle seam keeps the legacy snapshot at its immutable version route'
         archiveResult.task(':renderVersionedDocumentation').outcome == TaskOutcome.SUCCESS
-        new File(archiveOutput, 'archive/0.9.0/index.html').text.contains('Archived (legacy)')
-        !new File(archiveOutput, 'archive/0.9.0/api').exists()
-        !new File(archiveOutput, 'archive/0.9.0/assets/branding').exists()
+        new File(archiveOutput, '0.9.0/index.html').text.contains('Archived (legacy)')
+        !new File(archiveOutput, 'archive').exists()
+        !new File(archiveOutput, '0.9.0/api').exists()
+        !new File(archiveOutput, '0.9.0/assets/branding').exists()
     }
 
     @Language("groovy")

--- a/publication-smoke-tests/src/test/groovy/com/blackbuild/annodocimal/docs/VersionedDocumentationDocumentaryTest.groovy
+++ b/publication-smoke-tests/src/test/groovy/com/blackbuild/annodocimal/docs/VersionedDocumentationDocumentaryTest.groovy
@@ -65,6 +65,8 @@ class VersionedDocumentationDocumentaryTest extends Specification {
         writerJob.contains('Read back the canonical commit and source manifest')
         writerJob.contains('PAGES_WRITER_TOKEN')
         writerJob.contains('HEAD:gh-pages')
+        writerJob.contains('if [[ "$STATUS" == archived ]]')
+        writerJob.contains('git tag --points-at "$REVISION" "v$VERSION"')
 
         and: 'rendering and all other ordinary workflow jobs cannot receive or mint writer credentials'
         !renderJob.contains('PAGES_WRITER_')
@@ -86,7 +88,17 @@ class VersionedDocumentationDocumentaryTest extends Specification {
         documentation.contains('protected canonical writer job')
         documentation.contains('Pages-writer App')
 
-        and: 'public routing keeps every snapshot exact and advances only explicitly proof-gated aliases'
+    }
+
+    @See('https://github.com/blackbuild/anno-docimal/blob/master/docs/versioned-documentation.md#exact-snapshots')
+    def 'keeps public documentation routing immutable and proof-gated'() {
+        given: 'the checked-in protected publication contract'
+        File repository = new File(System.getProperty('annodocimal.repository.root'))
+        String publicationWorkflow = new File(repository, '.github/workflows/publish-versioned-documentation.yml').text
+        String documentation = new File(repository, 'docs/versioned-documentation.md').text
+        String writerJob = job(publicationWorkflow, 'write-canonical-immutable-snapshot')
+
+        expect: 'public routes keep an exact immutable tree and only proof-gated aliases move after deployment'
         publicationWorkflow.contains('alias_proof:')
         publicationWorkflow.contains('DEPLOY: ${{ inputs.deploy }}')
         publicationWorkflow.contains('[[ "$ALIAS_PROOF" =~ ^https://[^[:space:]]+$ ]]')
@@ -100,6 +112,8 @@ class VersionedDocumentationDocumentaryTest extends Specification {
         documentation.contains('`/archive/` is a discovery index')
         documentation.contains('`/stable/`, `/<maintained-line>/`, and `/preview/`')
         documentation.contains('`/pending/<version>/<full-source-sha>/`')
+        documentation.contains('VersionedDocumentationDocumentaryTest.keeps public documentation routing immutable and proof-gated')
+        documentation.contains('exact tagged historical source')
     }
 
     def 'demonstrates an immutable exact-site rehearsal'() {


### PR DESCRIPTION
## Summary

- Route every immutable RC, final, and historical snapshot at `/<version>/`; make `/archive/` a discovery index only.
- Add labelled, proof-gated `preview`, `stable`, and maintained-line aliases without a moving development site.
- Retain pending evidence at `pending/<version>/<full-source-sha>/` without alias or status advancement, and permit only exact tagged historical sources through the protected writer.

## Validation

- `./gradlew verifyVersionedDocumentationRenderer`
- `./gradlew :publication-smoke-tests:test --tests com.blackbuild.annodocimal.docs.VersionedDocumentationDocumentaryTest`
- `./gradlew check`
- Workflow YAML parse and `git diff --check`
- Two-axis standards/spec review

Related: #71. This PR leaves #71 open for its remaining #45 and authorized-release acceptance criteria.

No Pages configuration, deployment, release, tag, signing, or GitHub Release was performed.
