### PR TITLE
Update managed license year range

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2024 Stephan Pauxberger
+Copyright (c) 2024-2026 Stephan Pauxberger
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-annotations/src/main/java/com/blackbuild/annodocimal/annotations/AnnoDoc.java
+++ b/anno-docimal-annotations/src/main/java/com/blackbuild/annodocimal/annotations/AnnoDoc.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-annotations/src/main/java/com/blackbuild/annodocimal/annotations/GroovyPropertyDocumentation.java
+++ b/anno-docimal-annotations/src/main/java/com/blackbuild/annodocimal/annotations/GroovyPropertyDocumentation.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-annotations/src/main/java/com/blackbuild/annodocimal/annotations/InlineJavadocs.java
+++ b/anno-docimal-annotations/src/main/java/com/blackbuild/annodocimal/annotations/InlineJavadocs.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-apt/src/main/java/com/blackbuild/annodocimal/ast/AnnoDocimalAnnotationProcessor.java
+++ b/anno-docimal-apt/src/main/java/com/blackbuild/annodocimal/ast/AnnoDocimalAnnotationProcessor.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-apt/src/main/java/com/blackbuild/annodocimal/ast/JavadocPropertiesBuilder.java
+++ b/anno-docimal-apt/src/main/java/com/blackbuild/annodocimal/ast/JavadocPropertiesBuilder.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-apt/src/test/groovy/com/blackbuild/annodocimal/ast/AnnoDocimalAnnotationProcessorTest.groovy
+++ b/anno-docimal-apt/src/test/groovy/com/blackbuild/annodocimal/ast/AnnoDocimalAnnotationProcessorTest.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-ast/src/main/java/com/blackbuild/annodocimal/ast/AstDocumentation.java
+++ b/anno-docimal-ast/src/main/java/com/blackbuild/annodocimal/ast/AstDocumentation.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-ast/src/main/java/com/blackbuild/annodocimal/ast/Documentation.java
+++ b/anno-docimal-ast/src/main/java/com/blackbuild/annodocimal/ast/Documentation.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-ast/src/main/java/com/blackbuild/annodocimal/ast/InlineJavadocsTransformation.java
+++ b/anno-docimal-ast/src/main/java/com/blackbuild/annodocimal/ast/InlineJavadocsTransformation.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-ast/src/main/java/com/blackbuild/annodocimal/ast/InlineJavadocsVisitor.java
+++ b/anno-docimal-ast/src/main/java/com/blackbuild/annodocimal/ast/InlineJavadocsVisitor.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-ast/src/main/java/com/blackbuild/annodocimal/ast/extractor/ASTExtractor.java
+++ b/anno-docimal-ast/src/main/java/com/blackbuild/annodocimal/ast/extractor/ASTExtractor.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-ast/src/main/java/com/blackbuild/annodocimal/ast/extractor/ClassDocExtractor.java
+++ b/anno-docimal-ast/src/main/java/com/blackbuild/annodocimal/ast/extractor/ClassDocExtractor.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-ast/src/main/java/com/blackbuild/annodocimal/ast/extractor/InheritanceUtil.java
+++ b/anno-docimal-ast/src/main/java/com/blackbuild/annodocimal/ast/extractor/InheritanceUtil.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-ast/src/main/java/com/blackbuild/annodocimal/ast/formatting/AbstractDocBuilder.java
+++ b/anno-docimal-ast/src/main/java/com/blackbuild/annodocimal/ast/formatting/AbstractDocBuilder.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-ast/src/main/java/com/blackbuild/annodocimal/ast/formatting/AnnoDocUtil.java
+++ b/anno-docimal-ast/src/main/java/com/blackbuild/annodocimal/ast/formatting/AnnoDocUtil.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-ast/src/main/java/com/blackbuild/annodocimal/ast/formatting/DocBuilder.java
+++ b/anno-docimal-ast/src/main/java/com/blackbuild/annodocimal/ast/formatting/DocBuilder.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-ast/src/main/java/com/blackbuild/annodocimal/ast/formatting/DocText.java
+++ b/anno-docimal-ast/src/main/java/com/blackbuild/annodocimal/ast/formatting/DocText.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-ast/src/main/java/com/blackbuild/annodocimal/ast/formatting/JavaDocUtil.java
+++ b/anno-docimal-ast/src/main/java/com/blackbuild/annodocimal/ast/formatting/JavaDocUtil.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-ast/src/main/java/com/blackbuild/annodocimal/ast/formatting/JavadocDocBuilder.java
+++ b/anno-docimal-ast/src/main/java/com/blackbuild/annodocimal/ast/formatting/JavadocDocBuilder.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-ast/src/main/java/com/blackbuild/annodocimal/ast/formatting/TemplateHandler.java
+++ b/anno-docimal-ast/src/main/java/com/blackbuild/annodocimal/ast/formatting/TemplateHandler.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-ast/src/main/java/com/blackbuild/annodocimal/ast/parser/AbstractSourceExtractor.java
+++ b/anno-docimal-ast/src/main/java/com/blackbuild/annodocimal/ast/parser/AbstractSourceExtractor.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-ast/src/main/java/com/blackbuild/annodocimal/ast/parser/GroovyVersionHandler.java
+++ b/anno-docimal-ast/src/main/java/com/blackbuild/annodocimal/ast/parser/GroovyVersionHandler.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-ast/src/main/java/com/blackbuild/annodocimal/ast/parser/SourceExtractor.java
+++ b/anno-docimal-ast/src/main/java/com/blackbuild/annodocimal/ast/parser/SourceExtractor.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-ast/src/main/java/com/blackbuild/annodocimal/ast/parser/SourceExtractorFactory.java
+++ b/anno-docimal-ast/src/main/java/com/blackbuild/annodocimal/ast/parser/SourceExtractorFactory.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-ast/src/main/java/com/blackbuild/annodocimal/ast/parser/groovy3/Groovy3SourceExtractor.java
+++ b/anno-docimal-ast/src/main/java/com/blackbuild/annodocimal/ast/parser/groovy3/Groovy3SourceExtractor.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-ast/src/test/groovy/com/blackbuild/annodocimal/ast/AstDocumentationTest.groovy
+++ b/anno-docimal-ast/src/test/groovy/com/blackbuild/annodocimal/ast/AstDocumentationTest.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-ast/src/test/groovy/com/blackbuild/annodocimal/ast/ClassGeneratingSpecification.groovy
+++ b/anno-docimal-ast/src/test/groovy/com/blackbuild/annodocimal/ast/ClassGeneratingSpecification.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-ast/src/test/groovy/com/blackbuild/annodocimal/ast/DocumentationTest.groovy
+++ b/anno-docimal-ast/src/test/groovy/com/blackbuild/annodocimal/ast/DocumentationTest.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-ast/src/test/groovy/com/blackbuild/annodocimal/ast/DummyTransformation.groovy
+++ b/anno-docimal-ast/src/test/groovy/com/blackbuild/annodocimal/ast/DummyTransformation.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-ast/src/test/groovy/com/blackbuild/annodocimal/ast/GroovyPropertyDocumentationDocumentaryTest.groovy
+++ b/anno-docimal-ast/src/test/groovy/com/blackbuild/annodocimal/ast/GroovyPropertyDocumentationDocumentaryTest.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-ast/src/test/groovy/com/blackbuild/annodocimal/ast/InlineJavadocsTransformationTest.groovy
+++ b/anno-docimal-ast/src/test/groovy/com/blackbuild/annodocimal/ast/InlineJavadocsTransformationTest.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-ast/src/test/groovy/com/blackbuild/annodocimal/ast/MockAST.groovy
+++ b/anno-docimal-ast/src/test/groovy/com/blackbuild/annodocimal/ast/MockAST.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-ast/src/test/groovy/com/blackbuild/annodocimal/ast/MockableTransformation.groovy
+++ b/anno-docimal-ast/src/test/groovy/com/blackbuild/annodocimal/ast/MockableTransformation.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-ast/src/test/groovy/com/blackbuild/annodocimal/ast/SupportedApiBaselineTest.groovy
+++ b/anno-docimal-ast/src/test/groovy/com/blackbuild/annodocimal/ast/SupportedApiBaselineTest.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-ast/src/test/groovy/com/blackbuild/annodocimal/ast/extractor/ASTExtractorTest.groovy
+++ b/anno-docimal-ast/src/test/groovy/com/blackbuild/annodocimal/ast/extractor/ASTExtractorTest.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-ast/src/test/groovy/com/blackbuild/annodocimal/ast/extractor/AstHelper.groovy
+++ b/anno-docimal-ast/src/test/groovy/com/blackbuild/annodocimal/ast/extractor/AstHelper.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-ast/src/test/groovy/com/blackbuild/annodocimal/ast/extractor/ClassDocExtractorTest.groovy
+++ b/anno-docimal-ast/src/test/groovy/com/blackbuild/annodocimal/ast/extractor/ClassDocExtractorTest.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-ast/src/test/groovy/com/blackbuild/annodocimal/ast/extractor/InheritanceUtilTest.groovy
+++ b/anno-docimal-ast/src/test/groovy/com/blackbuild/annodocimal/ast/extractor/InheritanceUtilTest.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-ast/src/test/groovy/com/blackbuild/annodocimal/ast/formatting/AnnoDocUtilTest.groovy
+++ b/anno-docimal-ast/src/test/groovy/com/blackbuild/annodocimal/ast/formatting/AnnoDocUtilTest.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-ast/src/test/groovy/com/blackbuild/annodocimal/ast/formatting/DocTextTest.groovy
+++ b/anno-docimal-ast/src/test/groovy/com/blackbuild/annodocimal/ast/formatting/DocTextTest.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-ast/src/test/groovy/com/blackbuild/annodocimal/ast/formatting/JavaDocUtilTest.groovy
+++ b/anno-docimal-ast/src/test/groovy/com/blackbuild/annodocimal/ast/formatting/JavaDocUtilTest.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-ast/src/test/groovy/com/blackbuild/annodocimal/ast/formatting/JavadocDocBuilderTest.groovy
+++ b/anno-docimal-ast/src/test/groovy/com/blackbuild/annodocimal/ast/formatting/JavadocDocBuilderTest.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-ast/src/test/groovy/com/blackbuild/annodocimal/ast/formatting/ReadDocFrom.groovy
+++ b/anno-docimal-ast/src/test/groovy/com/blackbuild/annodocimal/ast/formatting/ReadDocFrom.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-ast/src/test/groovy/com/blackbuild/annodocimal/ast/formatting/TemplateHandlerTest.groovy
+++ b/anno-docimal-ast/src/test/groovy/com/blackbuild/annodocimal/ast/formatting/TemplateHandlerTest.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-ast/src/test/java/com/blackbuild/annodocimal/ast/SupportedNullabilityJavaConsumer.java
+++ b/anno-docimal-ast/src/test/java/com/blackbuild/annodocimal/ast/SupportedNullabilityJavaConsumer.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-ast/src/testFixtures/java/com/blackbuild/annodocimal/ast/extractor/mock/AClass.java
+++ b/anno-docimal-ast/src/testFixtures/java/com/blackbuild/annodocimal/ast/extractor/mock/AClass.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/ClassSignatureParser.java
+++ b/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/ClassSignatureParser.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/DeclarationVisibility.java
+++ b/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/DeclarationVisibility.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/FormalParameterParser.java
+++ b/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/FormalParameterParser.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/JavaPoetClassVisitor.java
+++ b/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/JavaPoetClassVisitor.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/MemberAnnotationVisitor.java
+++ b/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/MemberAnnotationVisitor.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/ProjectionPolicy.java
+++ b/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/ProjectionPolicy.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/ProjectionSelection.java
+++ b/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/ProjectionSelection.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/SourceProjectionException.java
+++ b/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/SourceProjectionException.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/SourceProjector.java
+++ b/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/SourceProjector.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/SpecConverter.java
+++ b/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/SpecConverter.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/TypeConversion.java
+++ b/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/TypeConversion.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/TypeSignatureParser.java
+++ b/anno-docimal-generator/src/main/java/com/blackbuild/annodocimal/generator/TypeSignatureParser.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/AnnoDocGeneratorJavaTest.groovy
+++ b/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/AnnoDocGeneratorJavaTest.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/AnnoDocGeneratorTest.groovy
+++ b/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/AnnoDocGeneratorTest.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/AnnotationMemberOrderingTest.groovy
+++ b/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/AnnotationMemberOrderingTest.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/ClassGeneratingTest.groovy
+++ b/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/ClassGeneratingTest.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/GroovyPropertyDocumentationTest.groovy
+++ b/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/GroovyPropertyDocumentationTest.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/GroovySourceProjectionContractTest.groovy
+++ b/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/GroovySourceProjectionContractTest.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/GroovydocInteroperabilityTest.groovy
+++ b/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/GroovydocInteroperabilityTest.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/JavaClassGeneratingTest.groovy
+++ b/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/JavaClassGeneratingTest.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/ProjectionContractAssertions.groovy
+++ b/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/ProjectionContractAssertions.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/SourceBlock.groovy
+++ b/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/SourceBlock.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/SourceBlockTest.groovy
+++ b/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/SourceBlockTest.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/SourceProjectionContractTest.groovy
+++ b/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/SourceProjectionContractTest.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/SourceProjectorGroovyTest.groovy
+++ b/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/SourceProjectorGroovyTest.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/SourceProjectorTest.groovy
+++ b/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/SourceProjectorTest.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/SupportedProjectionApiBaselineTest.groovy
+++ b/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/SupportedProjectionApiBaselineTest.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/TypeConversionTest.groovy
+++ b/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/generator/TypeConversionTest.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/testutil/GroovyVersionToSpec.groovy
+++ b/anno-docimal-generator/src/test/groovy/com/blackbuild/annodocimal/testutil/GroovyVersionToSpec.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-generator/src/test/java/com/blackbuild/annodocimal/generator/SupportedNullabilityJavaConsumer.java
+++ b/anno-docimal-generator/src/test/java/com/blackbuild/annodocimal/generator/SupportedNullabilityJavaConsumer.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-generator/src/test/java/dummy/GenericsHolder.java
+++ b/anno-docimal-generator/src/test/java/dummy/GenericsHolder.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-generator/src/test/java/dummyanno/Nested.java
+++ b/anno-docimal-generator/src/test/java/dummyanno/Nested.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-generator/src/test/java/dummyanno/WithEnum.java
+++ b/anno-docimal-generator/src/test/java/dummyanno/WithEnum.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-generator/src/test/java/dummyanno/WithPrimitives.java
+++ b/anno-docimal-generator/src/test/java/dummyanno/WithPrimitives.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-global-ast/src/main/java/com/blackbuild/annodocimal/global/ast/InlineJavadocsGlobalTransformation.java
+++ b/anno-docimal-global-ast/src/main/java/com/blackbuild/annodocimal/global/ast/InlineJavadocsGlobalTransformation.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-global-ast/src/test/groovy/com/blackbuild/annodocimal/ast/AbstractGlobalAstTest.groovy
+++ b/anno-docimal-global-ast/src/test/groovy/com/blackbuild/annodocimal/ast/AbstractGlobalAstTest.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-global-ast/src/test/groovy/com/blackbuild/annodocimal/ast/CapturePathConformanceTest.groovy
+++ b/anno-docimal-global-ast/src/test/groovy/com/blackbuild/annodocimal/ast/CapturePathConformanceTest.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-global-ast/src/test/groovy/com/blackbuild/annodocimal/ast/InlineJavadocsGlobalTransformationTest.groovy
+++ b/anno-docimal-global-ast/src/test/groovy/com/blackbuild/annodocimal/ast/InlineJavadocsGlobalTransformationTest.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-global-ast/src/test/groovy/com/blackbuild/annodocimal/ast/ModulePathVerificationTest.groovy
+++ b/anno-docimal-global-ast/src/test/groovy/com/blackbuild/annodocimal/ast/ModulePathVerificationTest.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-global-ast/src/test/groovy/com/blackbuild/annodocimal/ast/ScenarionsTest.groovy
+++ b/anno-docimal-global-ast/src/test/groovy/com/blackbuild/annodocimal/ast/ScenarionsTest.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-gradle-plugin/src/main/java/com/blackbuild/annodocimal/plugin/AnnoDocimalBasePlugin.java
+++ b/anno-docimal-gradle-plugin/src/main/java/com/blackbuild/annodocimal/plugin/AnnoDocimalBasePlugin.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-gradle-plugin/src/main/java/com/blackbuild/annodocimal/plugin/AnnoDocimalGroovyPlugin.java
+++ b/anno-docimal-gradle-plugin/src/main/java/com/blackbuild/annodocimal/plugin/AnnoDocimalGroovyPlugin.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-gradle-plugin/src/main/java/com/blackbuild/annodocimal/plugin/SourceProjectionTask.java
+++ b/anno-docimal-gradle-plugin/src/main/java/com/blackbuild/annodocimal/plugin/SourceProjectionTask.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-gradle-plugin/src/test/groovy/com/blackbuild/annodocimal/plugin/AnnoDocimalPluginTest.groovy
+++ b/anno-docimal-gradle-plugin/src/test/groovy/com/blackbuild/annodocimal/plugin/AnnoDocimalPluginTest.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-gradle-plugin/src/test/groovy/com/blackbuild/annodocimal/plugin/SupportedGradleApiBaselineTest.groovy
+++ b/anno-docimal-gradle-plugin/src/test/groovy/com/blackbuild/annodocimal/plugin/SupportedGradleApiBaselineTest.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/anno-docimal-gradle-plugin/src/test/groovy/com/blackbuild/annodocimal/plugin/TestScenario.groovy
+++ b/anno-docimal-gradle-plugin/src/test/groovy/com/blackbuild/annodocimal/plugin/TestScenario.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Stephan Pauxberger
+ * Copyright (c) 2024-2026 Stephan Pauxberger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary

Updates the root MIT license notice and all Gradle-managed Java/Groovy source headers from `2024` to the approved `2024-2026` range.

This is required 1.0 release-readiness work. It does not change licensing terms or ownership, and it is not a release action.

Related: #53 — issue state remains open.

## Scope

- Root `LICENSE` plus 92 Gradle-managed source headers
- No Gradle-wrapper copyright changes
- No text/mockup or other header-exempt files
- No version, tag, publication, signature, release, workflow, or environment changes

## Validation

- `./gradlew licenseFormat`
- `./gradlew license`
- `git diff --check`
- `./gradlew check` (baseline, Groovy 4, and Groovy 5 lanes)

## Review focus

Two-axis local review against `060ace5e8504fc0f5102f5ec2b66a2389d341b96` found no standards or specification findings. Review verified managed-header completeness and consistency, preserved exemptions, no license-term/ownership change, and no release-scope creep.

The first RC freeze resumes only after a maintainer merges this PR.
