### PR TITLE
Add protected RC and final release authorization

### DIFF
--- a/.github/workflows/publish-protected-release.yml
+++ b/.github/workflows/publish-protected-release.yml
@@ -1,0 +1,174 @@
+name: Publish protected AnnoDocimal release
+
+on:
+  workflow_dispatch:
+    inputs:
+      stage:
+        description: Exact independently authorized release stage
+        required: true
+        type: choice
+        options: [rc, final]
+      version:
+        description: Exact immutable X.Y.Z-rc.N or X.Y.Z version
+        required: true
+        type: string
+      revision:
+        description: Full lowercase source commit SHA on master
+        required: true
+        type: string
+      pending_documentation_path:
+        description: Existing protected pending documentation path for this exact stage, version, and source SHA
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: protected-release-${{ inputs.version }}
+  cancel-in-progress: false
+
+jobs:
+  validate-release-input:
+    name: Validate release identity and protected handoff
+    runs-on: ubuntu-latest
+    outputs:
+      environment: ${{ steps.select-environment.outputs.name }}
+      pending_documentation_path: ${{ steps.validate-pages-handoff.outputs.path }}
+    steps:
+      - id: select-environment
+        shell: bash
+        env:
+          RELEASE_STAGE: ${{ inputs.stage }}
+          RELEASE_VERSION: ${{ inputs.version }}
+          REVISION: ${{ inputs.revision }}
+        run: |
+          set -euo pipefail
+          [[ "$REVISION" =~ ^[0-9a-f]{40}$ ]]
+          if [[ "$RELEASE_STAGE" == rc && "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-rc\.[1-9][0-9]*$ ]]; then
+            echo 'name=annodocimal-release-rc' >> "$GITHUB_OUTPUT"
+          elif [[ "$RELEASE_STAGE" == final && "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo 'name=annodocimal-release-final' >> "$GITHUB_OUTPUT"
+          else
+            echo 'Stage must be rc or final and match the exact immutable version.' >&2
+            exit 1
+          fi
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ inputs.revision }}
+      - name: Require the requested source to be current master
+        shell: bash
+        env:
+          REVISION: ${{ inputs.revision }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$REVISION"
+          test "$(git rev-parse "$REVISION^{commit}")" = "$REVISION"
+          master_revision="$(git ls-remote --exit-code origin refs/heads/master | awk '{print $1}')"
+          test "$master_revision" = "$REVISION"
+          test -z "$(git status --porcelain=v1)"
+      - name: Reject a used tag or GitHub Release record
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          ! git show-ref --verify --quiet "refs/tags/v$VERSION"
+          release_status="$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' \
+            --header "Authorization: Bearer $GITHUB_TOKEN" \
+            --header 'X-GitHub-Api-Version: 2022-11-28' \
+            "https://api.github.com/repos/$GITHUB_REPOSITORY/releases/tags/v$VERSION")"
+          test "$release_status" = 404
+      - uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: pages
+          fetch-depth: 1
+          persist-credentials: false
+      - id: validate-pages-handoff
+        name: Require the exact pending documentation handoff and absent public target
+        shell: bash
+        env:
+          RELEASE_STAGE: ${{ inputs.stage }}
+          RELEASE_VERSION: ${{ inputs.version }}
+          REVISION: ${{ inputs.revision }}
+          PENDING_DOCUMENTATION_PATH: ${{ inputs.pending_documentation_path }}
+        run: |
+          set -euo pipefail
+          expected_path="pending/$RELEASE_VERSION/$REVISION"
+          test "$PENDING_DOCUMENTATION_PATH" = "$expected_path"
+          test ! -e "pages/$RELEASE_VERSION"
+          manifest="pages/$PENDING_DOCUMENTATION_PATH/source-manifest.json"
+          test -f "$manifest"
+          documentation_stage=candidate
+          if [[ "$RELEASE_STAGE" == final ]]; then documentation_stage=final; fi
+          jq -e --arg revision "$REVISION" --arg version "$RELEASE_VERSION" --arg stage "$documentation_stage" \
+            '.source.revision == $revision and .documentation.version == $version and .documentation.status == "pending" and .documentation.releaseStage == $stage' \
+            "$manifest" >/dev/null
+          echo "path=$PENDING_DOCUMENTATION_PATH" >> "$GITHUB_OUTPUT"
+
+  publish-complete-product:
+    name: Publish ${{ inputs.stage }} ${{ inputs.version }}
+    needs: validate-release-input
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    environment:
+      name: ${{ needs.validate-release-input.outputs.environment }}
+    env:
+      ANNODOCIMAL_RELEASE_AUTHORIZED: ${{ inputs.stage }}
+      ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
+      ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.SONATYPE_PASSWORD }}
+      ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
+      ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
+      GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
+      GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ inputs.revision }}
+      - name: Verify the protected source and pending documentation handoff
+        shell: bash
+        env:
+          REVISION: ${{ inputs.revision }}
+          PENDING_DOCUMENTATION_PATH: ${{ needs.validate-release-input.outputs.pending_documentation_path }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$REVISION"
+          master_revision="$(git ls-remote --exit-code origin refs/heads/master | awk '{print $1}')"
+          test "$master_revision" = "$REVISION"
+          test "$PENDING_DOCUMENTATION_PATH" = "pending/${{ inputs.version }}/$REVISION"
+          test -z "$(git status --porcelain=v1)"
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+      - uses: gradle/actions/setup-gradle@v4
+      - name: Require every protected credential before publication
+        shell: bash
+        run: |
+          set -euo pipefail
+          for credential in \
+            ORG_GRADLE_PROJECT_sonatypeUsername \
+            ORG_GRADLE_PROJECT_sonatypePassword \
+            ORG_GRADLE_PROJECT_signingKey \
+            ORG_GRADLE_PROJECT_signingPassword \
+            GRADLE_PUBLISH_KEY \
+            GRADLE_PUBLISH_SECRET
+          do
+            test -n "${!credential}" || {
+              echo "The selected protected environment is missing $credential." >&2
+              exit 1
+            }
+          done
+      - name: Verify, sign, stage, and publish the complete product
+        run: >-
+          ./gradlew publishCompleteProduct
+          -Prelease.stage=${{ inputs.stage }}
+          -Prelease.version=${{ inputs.version }}
+          --no-build-cache
+          --no-daemon

--- a/.github/workflows/publish-protected-release.yml
+++ b/.github/workflows/publish-protected-release.yml
@@ -36,7 +36,7 @@ jobs:
       environment: ${{ steps.select-environment.outputs.name }}
       pending_documentation_path: ${{ steps.validate-pages-handoff.outputs.path }}
     steps:
-      - id: select-environment
+      - name: Reject malformed release inputs
         shell: bash
         env:
           RELEASE_STAGE: ${{ inputs.stage }}
@@ -45,14 +45,7 @@ jobs:
         run: |
           set -euo pipefail
           [[ "$REVISION" =~ ^[0-9a-f]{40}$ ]]
-          if [[ "$RELEASE_STAGE" == rc && "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-rc\.[1-9][0-9]*$ ]]; then
-            echo 'name=annodocimal-release-rc' >> "$GITHUB_OUTPUT"
-          elif [[ "$RELEASE_STAGE" == final && "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo 'name=annodocimal-release-final' >> "$GITHUB_OUTPUT"
-          else
-            echo 'Stage must be rc or final and match the exact immutable version.' >&2
-            exit 1
-          fi
+          [[ "$RELEASE_STAGE" == rc || "$RELEASE_STAGE" == final ]]
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -69,6 +62,37 @@ jobs:
           master_revision="$(git ls-remote --exit-code origin refs/heads/master | awk '{print $1}')"
           test "$master_revision" = "$REVISION"
           test -z "$(git status --porcelain=v1)"
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+      - uses: gradle/actions/setup-gradle@v4
+      - name: Verify the exact source release identity before selecting an environment
+        shell: bash
+        env:
+          RELEASE_STAGE: ${{ inputs.stage }}
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: >-
+          ./gradlew verifyUnprivilegedReleaseInputs
+          -Prelease.stage="$RELEASE_STAGE"
+          -Prelease.version="$RELEASE_VERSION"
+          --no-build-cache
+          --no-daemon
+      - id: select-environment
+        shell: bash
+        env:
+          RELEASE_STAGE: ${{ inputs.stage }}
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if [[ "$RELEASE_STAGE" == rc && "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-rc\.[1-9][0-9]*$ ]]; then
+            echo 'name=annodocimal-release-rc' >> "$GITHUB_OUTPUT"
+          elif [[ "$RELEASE_STAGE" == final && "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo 'name=annodocimal-release-final' >> "$GITHUB_OUTPUT"
+          else
+            echo 'Stage must be rc or final and match the exact immutable version.' >&2
+            exit 1
+          fi
       - name: Reject a used tag or GitHub Release record
         shell: bash
         env:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -41,9 +41,9 @@ The protected release workflow itself needs an unprivileged preflight job. It st
 
 `Publish protected AnnoDocimal release` (`.github/workflows/publish-protected-release.yml`) is manually dispatched with
 the exact `stage`, `version`, full lowercase `revision`, and an existing
-`pending/<version>/<full-source-sha>` documentation path. The unprivileged preflight rejects any mismatched stage/version,
-non-current-master SHA, existing `v<version>` tag or GitHub Release record, missing/mismatched pending manifest, or an
-already occupied public `/<version>/` Pages target. It maps only `rc` to `annodocimal-release-rc` and `final` to
+`pending/<version>/<full-source-sha>` documentation path. The unprivileged preflight rejects any mismatched stage/version
+or source build identity, non-current-master SHA, existing `v<version>` tag or GitHub Release record,
+missing/mismatched pending manifest, or an already occupied public `/<version>/` Pages target. It maps only `rc` to `annodocimal-release-rc` and `final` to
 `annodocimal-release-final`; there is no default environment.
 
 Those two reviewer-gated, credential-bearing environments are separate from both `annodocimal-pages-writer` and the

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -37,6 +37,35 @@ Complete these checks while no protected environment has been selected. This is 
 
 The protected release workflow itself needs an unprivileged preflight job. It strictly accepts only `rc` or `final`, maps that accepted value to exactly the corresponding protected environment, and exports that selected environment as a job output. The publishing job consumes that output. Invalid input must reach neither protected environment nor secret; do not use a fallback expression that could select the final environment before rejecting an unexpected stage.
 
+## Protected authorization workflow
+
+`Publish protected AnnoDocimal release` (`.github/workflows/publish-protected-release.yml`) is manually dispatched with
+the exact `stage`, `version`, full lowercase `revision`, and an existing
+`pending/<version>/<full-source-sha>` documentation path. The unprivileged preflight rejects any mismatched stage/version,
+non-current-master SHA, existing `v<version>` tag or GitHub Release record, missing/mismatched pending manifest, or an
+already occupied public `/<version>/` Pages target. It maps only `rc` to `annodocimal-release-rc` and `final` to
+`annodocimal-release-final`; there is no default environment.
+
+Those two reviewer-gated, credential-bearing environments are separate from both `annodocimal-pages-writer` and the
+credential-free `github-pages` service environment. The publishing job alone receives `SONATYPE_USERNAME`,
+`SONATYPE_PASSWORD`, `SIGNING_KEY`, `SIGNING_PASSWORD`, `GRADLE_PUBLISH_KEY`, and `GRADLE_PUBLISH_SECRET`; it maps them
+only to Gradle's scoped publication inputs. Ordinary CI, preflight, release rehearsal, public resolve-back, and the Pages
+writer/service jobs have read-only repository access and none of those release secrets. Checkout credentials are never
+persisted.
+
+After reviewer approval, the publishing job repeats the exact-master and pending-handoff checks, requires Java 17, and
+runs `publishCompleteProduct`. That Gradle entry point rejects a non-matching protected stage/version authorization or a
+composite build, runs `check` and the six-coordinate/two-marker product gate before remote tasks, then stages/releases
+the Maven Central product and publishes both Plugin Portal markers. It does not create a tag, GitHub Release, or public
+Pages snapshot. The exact protected workflow is not a replacement for the existing protected Pages dispatches: first
+stage pending documentation, then publish the product, then complete #44 public resolve-back, then create the exact tag
+and CHANGES-derived GitHub Release, and only then dispatch the proof-gated public Pages handoff.
+
+This repository workflow defines names and code only. A maintainer must separately create and reviewer-protect
+`annodocimal-release-rc` and `annodocimal-release-final`, add only the listed secrets to their matching environment, and
+retain the existing Pages environment/ruleset setup. It does not create or configure environments, secrets, credentials,
+rulesets, Pages, tags, releases, uploads, or workflow runs.
+
 ## Complete product and release evidence
 
 Every RC and final uses one version across all six Maven Central coordinates:

--- a/build.gradle
+++ b/build.gradle
@@ -321,6 +321,87 @@ tasks.register('verifyPublicationReleaseConfiguration') {
     }
 }
 
+def protectedReleaseStage = providers.gradleProperty('release.stage')
+def protectedReleaseVersion = providers.gradleProperty('release.version')
+def protectedReleaseAuthorization = providers.environmentVariable('ANNODOCIMAL_RELEASE_AUTHORIZED')
+def validateProtectedReleaseAuthorization = {
+    if (!protectedReleaseStage.present || !(protectedReleaseStage.get() in ['rc', 'final']))
+        throw new GradleException('Set -Prelease.stage to exactly rc or final')
+    if (!protectedReleaseVersion.present)
+        throw new GradleException('Set -Prelease.version to the exact authorized RC or final version')
+
+    String stage = protectedReleaseStage.get()
+    String version = protectedReleaseVersion.get()
+    boolean versionMatchesStage = stage == 'rc'
+            ? version ==~ /\d+\.\d+\.\d+-rc\.[1-9]\d*/
+            : version ==~ /\d+\.\d+\.\d+/
+    if (!versionMatchesStage)
+        throw new GradleException("Release stage $stage does not match exact version $version")
+    if (!protectedReleaseAuthorization.present || protectedReleaseAuthorization.get() != stage)
+        throw new GradleException('Protected release authorization does not match -Prelease.stage')
+    if (project.version.toString() != version)
+        throw new GradleException("Configured release version $version does not match the build version $project.version")
+    if (!gradle.includedBuilds.empty)
+        throw new GradleException('Protected release publication does not allow composite builds')
+}
+def verifyProtectedReleaseAuthorization = tasks.register('verifyProtectedReleaseAuthorization') {
+    group = 'verification'
+    description = 'Rejects an unapproved, non-exact, or composite RC/final publication before remote tasks run.'
+    inputs.property('releaseStage', protectedReleaseStage.orElse(''))
+    inputs.property('releaseVersion', protectedReleaseVersion.orElse(''))
+    inputs.property('releaseAuthorization', protectedReleaseAuthorization.orElse(''))
+    doLast(validateProtectedReleaseAuthorization)
+}
+
+def protectedReleaseCentralPublicationTaskNames = [
+        [':anno-docimal-annotations', 'publishMavenJavaPublicationToSonatypeRepository'],
+        [':anno-docimal-apt', 'publishMavenJavaPublicationToSonatypeRepository'],
+        [':anno-docimal-ast', 'publishMavenJavaPublicationToSonatypeRepository'],
+        [':anno-docimal-global-ast', 'publishMavenJavaPublicationToSonatypeRepository'],
+        [':anno-docimal-generator', 'publishShadowPublicationToSonatypeRepository'],
+        [':anno-docimal-gradle-plugin', 'publishPluginMavenPublicationToSonatypeRepository']
+]
+def publishCompleteProduct = tasks.register('publishCompleteProduct') {
+    group = 'publishing'
+    description = 'Publishes the guarded six-coordinate product, releases Central staging, then publishes both plugin markers.'
+}
+def verifyCompleteProductPublication = tasks.register('verifyCompleteProductPublication') {
+    group = 'verification'
+    description = 'Rejects direct partial publication tasks that bypass the complete-product entry point.'
+    dependsOn verifyProtectedReleaseAuthorization
+    doLast {
+        if (!gradle.taskGraph.allTasks.any { it.path == ':publishCompleteProduct' })
+            throw new GradleException('Remote publication must use publishCompleteProduct for the complete product')
+    }
+}
+gradle.projectsEvaluated {
+    def centralPublicationTasks = protectedReleaseCentralPublicationTaskNames.collect { taskName ->
+        project(taskName[0]).tasks.named(taskName[1])
+    }
+    centralPublicationTasks.each { publicationTask ->
+        publicationTask.configure {
+            dependsOn rootProject.tasks.named('check')
+            dependsOn verifyCompleteProductPublication
+        }
+    }
+    def pluginMarkers = project(':anno-docimal-gradle-plugin').tasks.named('publishPlugins')
+    pluginMarkers.configure {
+        dependsOn rootProject.tasks.named('check')
+        dependsOn verifyCompleteProductPublication
+    }
+    def closeAndRelease = tasks.named('closeAndReleaseSonatypeStagingRepository') {
+        dependsOn centralPublicationTasks
+        mustRunAfter centralPublicationTasks
+    }
+    pluginMarkers.configure {
+        mustRunAfter closeAndRelease
+    }
+    publishCompleteProduct.configure {
+        dependsOn closeAndRelease
+        dependsOn pluginMarkers
+    }
+}
+
 tasks.register('publicRcSmoke') {
     group = 'verification'
     description = 'Runs exact-version consumer validation against public repositories only.'

--- a/build.gradle
+++ b/build.gradle
@@ -324,7 +324,7 @@ tasks.register('verifyPublicationReleaseConfiguration') {
 def protectedReleaseStage = providers.gradleProperty('release.stage')
 def protectedReleaseVersion = providers.gradleProperty('release.version')
 def protectedReleaseAuthorization = providers.environmentVariable('ANNODOCIMAL_RELEASE_AUTHORIZED')
-def validateProtectedReleaseAuthorization = {
+def validateUnprivilegedReleaseIdentity = {
     if (!protectedReleaseStage.present || !(protectedReleaseStage.get() in ['rc', 'final']))
         throw new GradleException('Set -Prelease.stage to exactly rc or final')
     if (!protectedReleaseVersion.present)
@@ -337,12 +337,22 @@ def validateProtectedReleaseAuthorization = {
             : version ==~ /\d+\.\d+\.\d+/
     if (!versionMatchesStage)
         throw new GradleException("Release stage $stage does not match exact version $version")
-    if (!protectedReleaseAuthorization.present || protectedReleaseAuthorization.get() != stage)
-        throw new GradleException('Protected release authorization does not match -Prelease.stage')
     if (project.version.toString() != version)
         throw new GradleException("Configured release version $version does not match the build version $project.version")
     if (!gradle.includedBuilds.empty)
         throw new GradleException('Protected release publication does not allow composite builds')
+}
+def verifyUnprivilegedReleaseInputs = tasks.register('verifyUnprivilegedReleaseInputs') {
+    group = 'verification'
+    description = 'Validates exact RC/final identity and rejects composite builds before environment selection.'
+    inputs.property('releaseStage', protectedReleaseStage.orElse(''))
+    inputs.property('releaseVersion', protectedReleaseVersion.orElse(''))
+    doLast(validateUnprivilegedReleaseIdentity)
+}
+def validateProtectedReleaseAuthorization = {
+    validateUnprivilegedReleaseIdentity()
+    if (!protectedReleaseAuthorization.present || protectedReleaseAuthorization.get() != protectedReleaseStage.get())
+        throw new GradleException('Protected release authorization does not match -Prelease.stage')
 }
 def verifyProtectedReleaseAuthorization = tasks.register('verifyProtectedReleaseAuthorization') {
     group = 'verification'

--- a/docs/publication-validation.md
+++ b/docs/publication-validation.md
@@ -44,6 +44,13 @@ substitutes for this check.
 publication, the Maven Central staging and snapshot endpoints, and the Gradle Plugin Portal publication task. It does
 not read signing credentials, create signatures, open a staging repository, or publish anything.
 
+`publishCompleteProduct` is the sole checked-in remote-product entry point. It first requires the protected
+`ANNODOCIMAL_RELEASE_AUTHORIZED` stage to agree with exact `-Prelease.stage` and `-Prelease.version` inputs, rejects
+composite builds, and runs root `check` before it can invoke any Central or Plugin Portal task. The manually dispatched
+release workflow selects that sentinel only after its unprivileged preflight maps the valid `rc` or `final` stage to the
+separate `annodocimal-release-rc` or `annodocimal-release-final` environment. It does not authorize a tag, GitHub
+Release, or Pages mutation; those remain ordered external steps in [the #45 runbook](../RELEASING.md).
+
 ## Authorized public RC validation
 
 After one exact immutable RC version has been explicitly authorized and published to the public repositories, validate

--- a/publication-smoke-tests/build.gradle
+++ b/publication-smoke-tests/build.gradle
@@ -67,14 +67,14 @@ tasks.register('preparePublicRcFixtures', Sync) {
 }
 
 tasks.register('publicRcGradleSmoke', GradleBuild) {
-    dependsOn tasks.named('preparePublicRcFixtures')
+    dependsOn project.tasks.named('preparePublicRcFixtures')
     dir publicRcFixtureDirectory.map { it.dir('gradle') }
     tasks = ['exerciseConsumer']
     startParameter.gradleUserHomeDir = publicRcGradleUserHome.get().asFile
 }
 
 tasks.register('publicRcMavenSmoke', Exec) {
-    dependsOn tasks.named('preparePublicRcFixtures')
+    dependsOn project.tasks.named('preparePublicRcFixtures')
     dependsOn rootProject.tasks.named('extractMaven')
     workingDir publicRcFixtureDirectory.map { it.dir('maven') }
     executable rootProject.layout.buildDirectory

--- a/publication-smoke-tests/src/test/groovy/com/blackbuild/annodocimal/publication/ProtectedReleaseAuthorizationContractTest.groovy
+++ b/publication-smoke-tests/src/test/groovy/com/blackbuild/annodocimal/publication/ProtectedReleaseAuthorizationContractTest.groovy
@@ -1,0 +1,136 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Stephan Pauxberger (Gradle Plugin) and others
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.blackbuild.annodocimal.publication
+
+import org.gradle.testkit.runner.GradleRunner
+import spock.lang.Issue
+import spock.lang.Specification
+
+import java.util.regex.Matcher
+import java.util.regex.Pattern
+
+@Issue('45')
+class ProtectedReleaseAuthorizationContractTest extends Specification {
+
+    def 'keeps RC and final authority in separately selected protected environments'() {
+        given: 'the checked-in protected release contract'
+        File repository = new File(System.getProperty('annodocimal.repository.root'))
+        String workflow = new File(repository, '.github/workflows/publish-protected-release.yml').text
+        String runbook = new File(repository, 'RELEASING.md').text
+        String preflight = job(workflow, 'validate-release-input')
+        String publishing = job(workflow, 'publish-complete-product')
+        String ordinaryWorkflow = workflow.replace(publishing, '')
+
+        expect: 'publication is manual, read-only until the selected environment provides authority'
+        workflow.contains('workflow_dispatch:')
+        !workflow.contains('pull_request:')
+        !workflow.contains('push:')
+        workflow.contains('contents: read')
+        preflight.contains('[[ "$REVISION" =~ ^[0-9a-f]{40}$ ]]')
+        preflight.contains('RELEASE_STAGE" == rc')
+        preflight.contains('RELEASE_STAGE" == final')
+        preflight.contains("echo 'name=annodocimal-release-rc'")
+        preflight.contains("echo 'name=annodocimal-release-final'")
+        !preflight.contains('secrets.')
+        !preflight.contains('\n    environment:\n')
+
+        and: 'the preflight fails closed before environment selection and proves source, tag, release record, and Pages handoff state'
+        !workflow.contains("&& 'annodocimal-release-rc' || 'annodocimal-release-final'")
+        workflow.contains('master_revision=')
+        workflow.contains('refs/tags/v$VERSION')
+        workflow.contains('release_status')
+        workflow.contains('test "$release_status" = 404')
+        workflow.contains('expected_path="pending/$RELEASE_VERSION/$REVISION"')
+        workflow.contains('test ! -e "pages/$RELEASE_VERSION"')
+        workflow.contains('.documentation.status == "pending"')
+
+        and: 'only the dependent protected job receives publication credentials'
+        publishing.contains('needs: validate-release-input')
+        publishing.contains('name: ${{ needs.validate-release-input.outputs.environment }}')
+        publishing.contains('ANNODOCIMAL_RELEASE_AUTHORIZED: ${{ inputs.stage }}')
+        publishing.contains('SONATYPE_USERNAME')
+        publishing.contains('SIGNING_KEY')
+        publishing.contains('GRADLE_PUBLISH_KEY')
+        publishing.contains('persist-credentials: false')
+        !ordinaryWorkflow.contains('SONATYPE_USERNAME')
+        !ordinaryWorkflow.contains('SIGNING_KEY')
+        !ordinaryWorkflow.contains('GRADLE_PUBLISH_KEY')
+
+        and: 'individual registry tasks cannot bypass the complete-product entry point'
+        new File(repository, 'build.gradle').text.contains("tasks.register('verifyCompleteProductPublication')")
+        new File(repository, 'build.gradle').text.contains('Remote publication must use publishCompleteProduct for the complete product')
+
+        and: 'the runbook keeps Page authority, public resolve-back, tags, and CHANGES-derived releases outside this workflow'
+        runbook.contains('`annodocimal-release-rc`')
+        runbook.contains('`annodocimal-release-final`')
+        runbook.contains('`annodocimal-pages-writer`')
+        runbook.contains('credential-free public resolve-back')
+        runbook.contains('GitHub Release body is copied or derived from the exact final `CHANGES.md` section')
+        runbook.contains('It does not create a tag, GitHub Release, or public')
+        runbook.contains('Pages snapshot.')
+    }
+
+    def 'rejects a Gradle publication without matching protected authorization'() {
+        given: 'the repository-local Gradle release gate'
+        File repository = new File(System.getProperty('annodocimal.repository.root'))
+        Map<String, String> environment = new LinkedHashMap<>(System.getenv())
+        environment.remove('ANNODOCIMAL_RELEASE_AUTHORIZED')
+
+        when: 'an RC-shaped version lacks the protected authorization sentinel'
+        def rejected = GradleRunner.create()
+                .withProjectDir(repository)
+                .withArguments('verifyProtectedReleaseAuthorization', '-Prelease.stage=rc', '-Prelease.version=1.0.0-rc.1')
+                .withEnvironment(environment)
+                .buildAndFail()
+
+        then: 'the guard fails before any publication task can run'
+        rejected.output.contains('Protected release authorization does not match -Prelease.stage')
+
+        when: 'the exact protected sentinel and version are supplied'
+        environment.put('ANNODOCIMAL_RELEASE_AUTHORIZED', 'rc')
+        def accepted = GradleRunner.create()
+                .withProjectDir(repository)
+                .withArguments('verifyProtectedReleaseAuthorization', '-Prelease.stage=rc', '-Prelease.version=1.0.0-rc.1')
+                .withEnvironment(environment)
+                .build()
+
+        then: 'the gate admits the identity without invoking a remote publication task'
+        accepted.output.contains('BUILD SUCCESSFUL')
+    }
+
+    private static String job(String workflow, String name) {
+        String marker = "  $name:\n"
+        int start = workflow.indexOf(marker)
+        assert start >= 0
+        Matcher headings = Pattern.compile('(?m)^  [a-z][a-z-]+:$').matcher(workflow)
+        int end = -1
+        while (headings.find()) {
+            if (headings.start() > start) {
+                end = headings.start()
+                break
+            }
+        }
+        end < 0 ? workflow.substring(start) : workflow.substring(start, end)
+    }
+}

--- a/publication-smoke-tests/src/test/groovy/com/blackbuild/annodocimal/publication/ProtectedReleaseAuthorizationContractTest.groovy
+++ b/publication-smoke-tests/src/test/groovy/com/blackbuild/annodocimal/publication/ProtectedReleaseAuthorizationContractTest.groovy
@@ -127,6 +127,23 @@ class ProtectedReleaseAuthorizationContractTest extends Specification {
     }
 
     @Unroll
+    def 'rejects #condition in the checked-in workflow preflight'() {
+        given: 'one exact validation step copied from the checked-in workflow'
+        File repository = new File(System.getProperty('annodocimal.repository.root'))
+        String workflow = new File(repository, '.github/workflows/publish-protected-release.yml').text
+
+        expect: 'the shell contract fails before it can reach a protected environment'
+        runBash(workflowStep(workflow, step), environment) != 0
+
+        where:
+        condition                 | step                                                                        | environment
+        'a non-lowercase SHA'     | 'Reject malformed release inputs'                                         | [RELEASE_STAGE: 'rc', RELEASE_VERSION: '1.0.0-rc.1', REVISION: 'A' * 40]
+        'a stale master SHA'      | 'Require the requested source to be current master'                       | staleMasterEnvironment()
+        'an existing release tag' | 'Reject a used tag or GitHub Release record'                              | existingTagEnvironment()
+        'a mismatched Pages path' | 'Require the exact pending documentation handoff and absent public target' | [RELEASE_STAGE: 'rc', RELEASE_VERSION: '1.0.0-rc.1', REVISION: 'a' * 40, PENDING_DOCUMENTATION_PATH: 'pending/other']
+    }
+
+    @Unroll
     def 'rejects malformed #stage release identity #version before environment selection'() {
         given: 'the credential-free Gradle preflight'
         File repository = new File(System.getProperty('annodocimal.repository.root'))
@@ -161,5 +178,57 @@ class ProtectedReleaseAuthorizationContractTest extends Specification {
             }
         }
         end < 0 ? workflow.substring(start) : workflow.substring(start, end)
+    }
+
+    private static String workflowStep(String workflow, String name) {
+        int stepStart = workflow.indexOf("name: $name\n")
+        assert stepStart >= 0
+        String runMarker = '        run: |\n'
+        int scriptStart = workflow.indexOf(runMarker, stepStart)
+        assert scriptStart >= 0
+        scriptStart += runMarker.length()
+        int scriptEnd = workflow.indexOf('\n      - ', scriptStart)
+        if (scriptEnd < 0)
+            scriptEnd = workflow.indexOf('\n  ', scriptStart)
+        String indentedScript = scriptEnd < 0 ? workflow.substring(scriptStart) : workflow.substring(scriptStart, scriptEnd)
+        indentedScript.readLines().collect { line -> line.size() >= 10 ? line.substring(10) : line }.join('\n')
+    }
+
+    private static int runBash(String script, Map<String, String> environment) {
+        ProcessBuilder process = new ProcessBuilder('bash', '-c', script)
+        environment.each { key, value -> process.environment().put(key, value.toString()) }
+        process.redirectErrorStream(true)
+        process.start().waitFor()
+    }
+
+    private static Map<String, String> staleMasterEnvironment() {
+        File bin = temporaryBin('stale-master')
+        new File(bin, 'git').text = '''#!/usr/bin/env bash
+case "$1:$2" in
+  rev-parse:HEAD|rev-parse:*) printf '%s\\n' "$REVISION" ;;
+  ls-remote:--exit-code) printf '%s\\trefs/heads/master\\n' bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb ;;
+  status:--porcelain=v1) ;;
+  *) exit 1 ;;
+esac
+'''
+        new File(bin, 'git').setExecutable(true)
+        [REVISION: 'a' * 40, PATH: "$bin:${System.getenv('PATH')}"]
+    }
+
+    private static Map<String, String> existingTagEnvironment() {
+        File bin = temporaryBin('existing-tag')
+        new File(bin, 'git').text = '''#!/usr/bin/env bash
+[[ "$1" == show-ref ]]
+'''
+        new File(bin, 'git').setExecutable(true)
+        [VERSION: '1.0.0-rc.1', GITHUB_TOKEN: 'fixture-token', PATH: "$bin:${System.getenv('PATH')}"]
+    }
+
+    private static File temporaryBin(String prefix) {
+        File directory = File.createTempFile(prefix, '')
+        assert directory.delete()
+        assert directory.mkdir()
+        directory.deleteOnExit()
+        directory
     }
 }

--- a/publication-smoke-tests/src/test/groovy/com/blackbuild/annodocimal/publication/ProtectedReleaseAuthorizationContractTest.groovy
+++ b/publication-smoke-tests/src/test/groovy/com/blackbuild/annodocimal/publication/ProtectedReleaseAuthorizationContractTest.groovy
@@ -25,12 +25,17 @@ package com.blackbuild.annodocimal.publication
 
 import org.gradle.testkit.runner.GradleRunner
 import spock.lang.Issue
+import spock.lang.See
 import spock.lang.Specification
+import spock.lang.Tag
+import spock.lang.Unroll
 
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 
 @Issue('45')
+@Tag('documentary')
+@See('https://github.com/blackbuild/anno-docimal/blob/master/RELEASING.md#protected-authorization-workflow')
 class ProtectedReleaseAuthorizationContractTest extends Specification {
 
     def 'keeps RC and final authority in separately selected protected environments'() {
@@ -64,6 +69,8 @@ class ProtectedReleaseAuthorizationContractTest extends Specification {
         workflow.contains('expected_path="pending/$RELEASE_VERSION/$REVISION"')
         workflow.contains('test ! -e "pages/$RELEASE_VERSION"')
         workflow.contains('.documentation.status == "pending"')
+        workflow.contains('./gradlew verifyUnprivilegedReleaseInputs')
+        workflow.contains('test "$master_revision" = "$REVISION"')
 
         and: 'only the dependent protected job receives publication credentials'
         publishing.contains('needs: validate-release-input')
@@ -117,6 +124,28 @@ class ProtectedReleaseAuthorizationContractTest extends Specification {
 
         then: 'the gate admits the identity without invoking a remote publication task'
         accepted.output.contains('BUILD SUCCESSFUL')
+    }
+
+    @Unroll
+    def 'rejects malformed #stage release identity #version before environment selection'() {
+        given: 'the credential-free Gradle preflight'
+        File repository = new File(System.getProperty('annodocimal.repository.root'))
+
+        when:
+        def rejected = GradleRunner.create()
+                .withProjectDir(repository)
+                .withArguments('verifyUnprivilegedReleaseInputs', "-Prelease.stage=$stage", "-Prelease.version=$version")
+                .buildAndFail()
+
+        then:
+        rejected.output.contains(message)
+
+        where:
+        stage       | version        || message
+        'candidate' | '1.0.0-rc.1'   || 'Set -Prelease.stage to exactly rc or final'
+        'rc'        | '1.0.0'        || 'Release stage rc does not match exact version 1.0.0'
+        'final'     | '1.0.0-rc.1'   || 'Release stage final does not match exact version 1.0.0-rc.1'
+        'rc'        | '1.0.0-rc.0'   || 'Release stage rc does not match exact version 1.0.0-rc.0'
     }
 
     private static String job(String workflow, String name) {


### PR DESCRIPTION
## Summary

Implements REL-AUTH-1 for issue #45: a manually dispatched, fail-closed protected RC/final publication workflow with independently selected reviewer-gated environments.

- validates exact stage, version, current-master SHA, prior tag/release absence, and pending Pages handoff before environment selection;
- confines Maven Central, signing, and Plugin Portal credentials to the selected publishing job;
- gates the complete six-coordinate/two-marker publication and blocks direct partial publication tasks;
- documents the #44 resolve-back, CHANGES-derived release, Pages handoff, and burned-version recovery contracts.

Issue #45 remains open: this PR creates no environment, secret, credential, Pages setting, tag, release, upload, or workflow run.

## Validation

- `./gradlew :publication-smoke-tests:test --tests com.blackbuild.annodocimal.publication.ProtectedReleaseAuthorizationContractTest`
- `./gradlew check`
- Standards review: no findings
- Spec review: no findings