### PR TITLE
Extract protected release convention

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ buildscript {
 plugins {
     id 'nebula.release'
     id 'base'
+    id 'annodocimal-release.conventions'
 
     id "com.github.hierynomus.license"
     id "com.github.ben-manes.versions"
@@ -60,6 +61,20 @@ nexusPublishing {
             snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
         }
     }
+}
+
+protectedRelease {
+    centralPublicationTasks = [
+            ':anno-docimal-annotations:publishMavenJavaPublicationToSonatypeRepository',
+            ':anno-docimal-apt:publishMavenJavaPublicationToSonatypeRepository',
+            ':anno-docimal-ast:publishMavenJavaPublicationToSonatypeRepository',
+            ':anno-docimal-global-ast:publishMavenJavaPublicationToSonatypeRepository',
+            ':anno-docimal-generator:publishShadowPublicationToSonatypeRepository',
+            ':anno-docimal-gradle-plugin:publishPluginMavenPublicationToSonatypeRepository'
+    ]
+    pluginMarkerTasks = [
+            ':anno-docimal-gradle-plugin:publishPlugins'
+    ]
 }
 
 sonar {
@@ -318,97 +333,6 @@ tasks.register('verifyPublicationReleaseConfiguration') {
             throw new GradleException("Unexpected Sonatype snapshot URL: ${sonatype.snapshotRepositoryUrl.get()}")
         if (project(':anno-docimal-gradle-plugin').tasks.findByName('publishPlugins') == null)
             throw new GradleException('The Gradle Plugin Portal publication task is not configured')
-    }
-}
-
-def protectedReleaseStage = providers.gradleProperty('release.stage')
-def protectedReleaseVersion = providers.gradleProperty('release.version')
-def protectedReleaseAuthorization = providers.environmentVariable('ANNODOCIMAL_RELEASE_AUTHORIZED')
-def validateUnprivilegedReleaseIdentity = {
-    if (!protectedReleaseStage.present || !(protectedReleaseStage.get() in ['rc', 'final']))
-        throw new GradleException('Set -Prelease.stage to exactly rc or final')
-    if (!protectedReleaseVersion.present)
-        throw new GradleException('Set -Prelease.version to the exact authorized RC or final version')
-
-    String stage = protectedReleaseStage.get()
-    String version = protectedReleaseVersion.get()
-    boolean versionMatchesStage = stage == 'rc'
-            ? version ==~ /\d+\.\d+\.\d+-rc\.[1-9]\d*/
-            : version ==~ /\d+\.\d+\.\d+/
-    if (!versionMatchesStage)
-        throw new GradleException("Release stage $stage does not match exact version $version")
-    if (project.version.toString() != version)
-        throw new GradleException("Configured release version $version does not match the build version $project.version")
-    if (!gradle.includedBuilds.empty)
-        throw new GradleException('Protected release publication does not allow composite builds')
-}
-def verifyUnprivilegedReleaseInputs = tasks.register('verifyUnprivilegedReleaseInputs') {
-    group = 'verification'
-    description = 'Validates exact RC/final identity and rejects composite builds before environment selection.'
-    inputs.property('releaseStage', protectedReleaseStage.orElse(''))
-    inputs.property('releaseVersion', protectedReleaseVersion.orElse(''))
-    doLast(validateUnprivilegedReleaseIdentity)
-}
-def validateProtectedReleaseAuthorization = {
-    validateUnprivilegedReleaseIdentity()
-    if (!protectedReleaseAuthorization.present || protectedReleaseAuthorization.get() != protectedReleaseStage.get())
-        throw new GradleException('Protected release authorization does not match -Prelease.stage')
-}
-def verifyProtectedReleaseAuthorization = tasks.register('verifyProtectedReleaseAuthorization') {
-    group = 'verification'
-    description = 'Rejects an unapproved, non-exact, or composite RC/final publication before remote tasks run.'
-    inputs.property('releaseStage', protectedReleaseStage.orElse(''))
-    inputs.property('releaseVersion', protectedReleaseVersion.orElse(''))
-    inputs.property('releaseAuthorization', protectedReleaseAuthorization.orElse(''))
-    doLast(validateProtectedReleaseAuthorization)
-}
-
-def protectedReleaseCentralPublicationTaskNames = [
-        [':anno-docimal-annotations', 'publishMavenJavaPublicationToSonatypeRepository'],
-        [':anno-docimal-apt', 'publishMavenJavaPublicationToSonatypeRepository'],
-        [':anno-docimal-ast', 'publishMavenJavaPublicationToSonatypeRepository'],
-        [':anno-docimal-global-ast', 'publishMavenJavaPublicationToSonatypeRepository'],
-        [':anno-docimal-generator', 'publishShadowPublicationToSonatypeRepository'],
-        [':anno-docimal-gradle-plugin', 'publishPluginMavenPublicationToSonatypeRepository']
-]
-def publishCompleteProduct = tasks.register('publishCompleteProduct') {
-    group = 'publishing'
-    description = 'Publishes the guarded six-coordinate product, releases Central staging, then publishes both plugin markers.'
-}
-def verifyCompleteProductPublication = tasks.register('verifyCompleteProductPublication') {
-    group = 'verification'
-    description = 'Rejects direct partial publication tasks that bypass the complete-product entry point.'
-    dependsOn verifyProtectedReleaseAuthorization
-    doLast {
-        if (!gradle.taskGraph.allTasks.any { it.path == ':publishCompleteProduct' })
-            throw new GradleException('Remote publication must use publishCompleteProduct for the complete product')
-    }
-}
-gradle.projectsEvaluated {
-    def centralPublicationTasks = protectedReleaseCentralPublicationTaskNames.collect { taskName ->
-        project(taskName[0]).tasks.named(taskName[1])
-    }
-    centralPublicationTasks.each { publicationTask ->
-        publicationTask.configure {
-            dependsOn rootProject.tasks.named('check')
-            dependsOn verifyCompleteProductPublication
-        }
-    }
-    def pluginMarkers = project(':anno-docimal-gradle-plugin').tasks.named('publishPlugins')
-    pluginMarkers.configure {
-        dependsOn rootProject.tasks.named('check')
-        dependsOn verifyCompleteProductPublication
-    }
-    def closeAndRelease = tasks.named('closeAndReleaseSonatypeStagingRepository') {
-        dependsOn centralPublicationTasks
-        mustRunAfter centralPublicationTasks
-    }
-    pluginMarkers.configure {
-        mustRunAfter closeAndRelease
-    }
-    publishCompleteProduct.configure {
-        dependsOn closeAndRelease
-        dependsOn pluginMarkers
     }
 }
 

--- a/buildSrc/src/main/groovy/annodocimal-release.conventions.gradle
+++ b/buildSrc/src/main/groovy/annodocimal-release.conventions.gradle
@@ -1,0 +1,94 @@
+import com.blackbuild.annodocimal.release.ProtectedReleaseConventionExtension
+import org.gradle.api.GradleException
+
+if (project != rootProject)
+    throw new GradleException('annodocimal-release.conventions must be applied to the root project')
+
+def protectedRelease = extensions.create('protectedRelease', ProtectedReleaseConventionExtension)
+def protectedReleaseStage = providers.gradleProperty('release.stage')
+def protectedReleaseVersion = providers.gradleProperty('release.version')
+def protectedReleaseAuthorization = providers.environmentVariable('ANNODOCIMAL_RELEASE_AUTHORIZED')
+def validateUnprivilegedReleaseIdentity = {
+    if (!protectedReleaseStage.present || !(protectedReleaseStage.get() in ['rc', 'final']))
+        throw new GradleException('Set -Prelease.stage to exactly rc or final')
+    if (!protectedReleaseVersion.present)
+        throw new GradleException('Set -Prelease.version to the exact authorized RC or final version')
+
+    String stage = protectedReleaseStage.get()
+    String version = protectedReleaseVersion.get()
+    boolean versionMatchesStage = stage == 'rc'
+            ? version ==~ /\d+\.\d+\.\d+-rc\.[1-9]\d*/
+            : version ==~ /\d+\.\d+\.\d+/
+    if (!versionMatchesStage)
+        throw new GradleException("Release stage $stage does not match exact version $version")
+    if (project.version.toString() != version)
+        throw new GradleException("Configured release version $version does not match the build version $project.version")
+    if (!gradle.includedBuilds.empty)
+        throw new GradleException('Protected release publication does not allow composite builds')
+}
+def verifyUnprivilegedReleaseInputs = tasks.register('verifyUnprivilegedReleaseInputs') {
+    group = 'verification'
+    description = 'Validates exact RC/final identity and rejects composite builds before environment selection.'
+    inputs.property('releaseStage', protectedReleaseStage.orElse(''))
+    inputs.property('releaseVersion', protectedReleaseVersion.orElse(''))
+    doLast(validateUnprivilegedReleaseIdentity)
+}
+def validateProtectedReleaseAuthorization = {
+    validateUnprivilegedReleaseIdentity()
+    if (!protectedReleaseAuthorization.present || protectedReleaseAuthorization.get() != protectedReleaseStage.get())
+        throw new GradleException('Protected release authorization does not match -Prelease.stage')
+}
+def verifyProtectedReleaseAuthorization = tasks.register('verifyProtectedReleaseAuthorization') {
+    group = 'verification'
+    description = 'Rejects an unapproved, non-exact, or composite RC/final publication before remote tasks run.'
+    inputs.property('releaseStage', protectedReleaseStage.orElse(''))
+    inputs.property('releaseVersion', protectedReleaseVersion.orElse(''))
+    inputs.property('releaseAuthorization', protectedReleaseAuthorization.orElse(''))
+    doLast(validateProtectedReleaseAuthorization)
+}
+
+def publishCompleteProduct = tasks.register('publishCompleteProduct') {
+    group = 'publishing'
+    description = 'Publishes the guarded six-coordinate product, releases Central staging, then publishes both plugin markers.'
+}
+def verifyCompleteProductPublication = tasks.register('verifyCompleteProductPublication') {
+    group = 'verification'
+    description = 'Rejects direct partial publication tasks that bypass the complete-product entry point.'
+    dependsOn verifyProtectedReleaseAuthorization
+    doLast {
+        if (!gradle.taskGraph.allTasks.any { it.path == ':publishCompleteProduct' })
+            throw new GradleException('Remote publication must use publishCompleteProduct for the complete product')
+    }
+}
+gradle.projectsEvaluated {
+    if (protectedRelease.centralPublicationTasks.empty || protectedRelease.pluginMarkerTasks.empty)
+        throw new GradleException('Configure Central and Plugin Portal publication tasks for the protected release convention')
+
+    def taskProviderFor = { String taskPath ->
+        int separator = taskPath.lastIndexOf(':')
+        if (separator <= 0 || separator == taskPath.length() - 1)
+            throw new GradleException("Invalid protected release task path $taskPath")
+        project(taskPath.substring(0, separator)).tasks.named(taskPath.substring(separator + 1))
+    }
+    def centralPublicationTasks = protectedRelease.centralPublicationTasks.collect(taskProviderFor)
+    def pluginMarkerTasks = protectedRelease.pluginMarkerTasks.collect(taskProviderFor)
+    (centralPublicationTasks + pluginMarkerTasks).each { publicationTask ->
+        publicationTask.configure {
+            dependsOn rootProject.tasks.named('check')
+            dependsOn verifyCompleteProductPublication
+        }
+    }
+    def closeAndRelease = tasks.named('closeAndReleaseSonatypeStagingRepository') {
+        dependsOn centralPublicationTasks
+        mustRunAfter centralPublicationTasks
+    }
+    pluginMarkerTasks.each { pluginMarkerTask ->
+        pluginMarkerTask.configure {
+            mustRunAfter closeAndRelease
+        }
+    }
+    publishCompleteProduct.configure {
+        dependsOn closeAndRelease
+        dependsOn pluginMarkerTasks
+    }
+}

--- a/buildSrc/src/main/groovy/com/blackbuild/annodocimal/release/ProtectedReleaseConventionExtension.groovy
+++ b/buildSrc/src/main/groovy/com/blackbuild/annodocimal/release/ProtectedReleaseConventionExtension.groovy
@@ -1,0 +1,30 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Stephan Pauxberger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.blackbuild.annodocimal.release
+
+/** Product-specific publication task paths supplied by the root build. */
+class ProtectedReleaseConventionExtension {
+    List<String> centralPublicationTasks = []
+    List<String> pluginMarkerTasks = []
+}

--- a/publication-smoke-tests/src/test/groovy/com/blackbuild/annodocimal/publication/ProtectedReleaseAuthorizationContractTest.groovy
+++ b/publication-smoke-tests/src/test/groovy/com/blackbuild/annodocimal/publication/ProtectedReleaseAuthorizationContractTest.groovy
@@ -84,9 +84,24 @@ class ProtectedReleaseAuthorizationContractTest extends Specification {
         !ordinaryWorkflow.contains('SIGNING_KEY')
         !ordinaryWorkflow.contains('GRADLE_PUBLISH_KEY')
 
-        and: 'individual registry tasks cannot bypass the complete-product entry point'
-        new File(repository, 'build.gradle').text.contains("tasks.register('verifyCompleteProductPublication')")
-        new File(repository, 'build.gradle').text.contains('Remote publication must use publishCompleteProduct for the complete product')
+        and: 'the root declares product coordinates while the convention owns guarded task wiring'
+        String rootBuild = new File(repository, 'build.gradle').text
+        String convention = new File(repository, 'buildSrc/src/main/groovy/annodocimal-release.conventions.gradle').text
+        rootBuild.contains("id 'annodocimal-release.conventions'")
+        rootBuild.contains('protectedRelease {')
+        [
+                ':anno-docimal-annotations:publishMavenJavaPublicationToSonatypeRepository',
+                ':anno-docimal-apt:publishMavenJavaPublicationToSonatypeRepository',
+                ':anno-docimal-ast:publishMavenJavaPublicationToSonatypeRepository',
+                ':anno-docimal-global-ast:publishMavenJavaPublicationToSonatypeRepository',
+                ':anno-docimal-generator:publishShadowPublicationToSonatypeRepository',
+                ':anno-docimal-gradle-plugin:publishPluginMavenPublication'
+        ].every { taskPath -> rootBuild.contains(taskPath) }
+        rootBuild.contains(':anno-docimal-gradle-plugin:publishPlugins')
+        !rootBuild.contains("tasks.register('verifyCompleteProductPublication')")
+        convention.contains("tasks.register('verifyCompleteProductPublication')")
+        convention.contains("tasks.register('publishCompleteProduct')")
+        convention.contains('Remote publication must use publishCompleteProduct for the complete product')
 
         and: 'the runbook keeps Page authority, public resolve-back, tags, and CHANGES-derived releases outside this workflow'
         runbook.contains('`annodocimal-release-rc`')


### PR DESCRIPTION
## What changed

Extracts the protected RC/final release-task registration, validation, and complete-product wiring from the root build into a root-applied `buildSrc` convention plugin.

The root build now declares only the plugin and AnnoDocimal-specific publication task paths: six Maven Central coordinates and the Plugin Portal marker task.

## Why

This keeps the product-root `:` task entry points while removing their implementation detail from the normal root build script.

## Impact and safety

The protected-release workflow, environment/secret boundary, remote publication behavior, and repository setup are unchanged. This PR neither configures nor invokes a release.

## Validation

- `./gradlew :publication-smoke-tests:test --tests com.blackbuild.annodocimal.publication.ProtectedReleaseAuthorizationContractTest`
- `./gradlew check`
- Standards review: 0 findings
- Spec review: 0 findings

Follow-up to #45; does not close it.