### PR TITLE
Align #45 release environment names

### DIFF
--- a/.github/workflows/publish-protected-release.yml
+++ b/.github/workflows/publish-protected-release.yml
@@ -86,9 +86,9 @@ jobs:
         run: |
           set -euo pipefail
           if [[ "$RELEASE_STAGE" == rc && "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-rc\.[1-9][0-9]*$ ]]; then
-            echo 'name=annodocimal-release-rc' >> "$GITHUB_OUTPUT"
+            echo 'name=release-candidate' >> "$GITHUB_OUTPUT"
           elif [[ "$RELEASE_STAGE" == final && "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo 'name=annodocimal-release-final' >> "$GITHUB_OUTPUT"
+            echo 'name=final-release' >> "$GITHUB_OUTPUT"
           else
             echo 'Stage must be rc or final and match the exact immutable version.' >&2
             exit 1

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -43,8 +43,8 @@ The protected release workflow itself needs an unprivileged preflight job. It st
 the exact `stage`, `version`, full lowercase `revision`, and an existing
 `pending/<version>/<full-source-sha>` documentation path. The unprivileged preflight rejects any mismatched stage/version
 or source build identity, non-current-master SHA, existing `v<version>` tag or GitHub Release record,
-missing/mismatched pending manifest, or an already occupied public `/<version>/` Pages target. It maps only `rc` to `annodocimal-release-rc` and `final` to
-`annodocimal-release-final`; there is no default environment.
+missing/mismatched pending manifest, or an already occupied public `/<version>/` Pages target. It maps only `rc` to `release-candidate` and `final` to
+`final-release`; there is no default environment.
 
 Those two reviewer-gated, credential-bearing environments are separate from both `annodocimal-pages-writer` and the
 credential-free `github-pages` service environment. The publishing job alone receives `SONATYPE_USERNAME`,
@@ -62,7 +62,7 @@ stage pending documentation, then publish the product, then complete #44 public 
 and CHANGES-derived GitHub Release, and only then dispatch the proof-gated public Pages handoff.
 
 This repository workflow defines names and code only. A maintainer must separately create and reviewer-protect
-`annodocimal-release-rc` and `annodocimal-release-final`, add only the listed secrets to their matching environment, and
+`release-candidate` and `final-release`, add only the listed secrets to their matching environment, and
 retain the existing Pages environment/ruleset setup. It does not create or configure environments, secrets, credentials,
 rulesets, Pages, tags, releases, uploads, or workflow runs.
 

--- a/publication-smoke-tests/src/test/groovy/com/blackbuild/annodocimal/publication/ProtectedReleaseAuthorizationContractTest.groovy
+++ b/publication-smoke-tests/src/test/groovy/com/blackbuild/annodocimal/publication/ProtectedReleaseAuthorizationContractTest.groovy
@@ -55,13 +55,13 @@ class ProtectedReleaseAuthorizationContractTest extends Specification {
         preflight.contains('[[ "$REVISION" =~ ^[0-9a-f]{40}$ ]]')
         preflight.contains('RELEASE_STAGE" == rc')
         preflight.contains('RELEASE_STAGE" == final')
-        preflight.contains("echo 'name=annodocimal-release-rc'")
-        preflight.contains("echo 'name=annodocimal-release-final'")
+        preflight.contains("echo 'name=release-candidate'")
+        preflight.contains("echo 'name=final-release'")
         !preflight.contains('secrets.')
         !preflight.contains('\n    environment:\n')
 
         and: 'the preflight fails closed before environment selection and proves source, tag, release record, and Pages handoff state'
-        !workflow.contains("&& 'annodocimal-release-rc' || 'annodocimal-release-final'")
+        !workflow.contains("&& 'release-candidate' || 'final-release'")
         workflow.contains('master_revision=')
         workflow.contains('refs/tags/v$VERSION')
         workflow.contains('release_status')
@@ -104,8 +104,8 @@ class ProtectedReleaseAuthorizationContractTest extends Specification {
         convention.contains('Remote publication must use publishCompleteProduct for the complete product')
 
         and: 'the runbook keeps Page authority, public resolve-back, tags, and CHANGES-derived releases outside this workflow'
-        runbook.contains('`annodocimal-release-rc`')
-        runbook.contains('`annodocimal-release-final`')
+        runbook.contains('`release-candidate`')
+        runbook.contains('`final-release`')
         runbook.contains('`annodocimal-pages-writer`')
         runbook.contains('credential-free public resolve-back')
         runbook.contains('GitHub Release body is copied or derived from the exact final `CHANGES.md` section')


### PR DESCRIPTION
## Summary

Aligns AnnoDocimal’s protected release environment names with the shared library convention:

- `release-candidate` for RC publication
- `final-release` for final publication

The strict preflight mapping remains fail-closed; credential confinement and all release behavior are unchanged.

Related: #45 remains open.

## Validation

- `./gradlew :publication-smoke-tests:test --tests com.blackbuild.annodocimal.publication.ProtectedReleaseAuthorizationContractTest`
- `./gradlew check`
- YAML parse and `git diff --check`
- Standards review: no findings
- Spec review: no findings