### PR TITLE
Preserve staged Pages manifest for read-back

### DIFF
--- a/.github/workflows/publish-versioned-documentation.yml
+++ b/.github/workflows/publish-versioned-documentation.yml
@@ -224,7 +224,7 @@ jobs:
           mkdir -p pages
           touch pages/.nojekyll
           mkdir -p "pages/$(dirname "$SNAPSHOT_PATH")"
-          mv "rendered/$RENDER_PATH" "pages/$SNAPSHOT_PATH"
+          cp -R "rendered/$RENDER_PATH" "pages/$SNAPSHOT_PATH"
 
           write_alias() {
             local alias="$1"

--- a/docs/versioned-documentation.md
+++ b/docs/versioned-documentation.md
@@ -86,9 +86,10 @@ used only for the `gh-pages` push. Before that push, the writer resolves `refs/h
 continue unless a pending, public-RC, or current source revision is its exact tip. The narrow archived exception accepts
 only an exact tagged historical source (`v<version>`), so a legacy snapshot can be published at its immutable version
 route and added to `/archive/` without weakening the non-archive master boundary. It also verifies that the staged
-`source-manifest.json` binds that source, version, and status. After the push, a fresh remote checkout must resolve to
-the pushed commit and contain byte-identical manifest content with the same source/version/status binding. A missing
-protected-environment value fails the writer before token minting or canonical mutation.
+`source-manifest.json` binds that source, version, and status. The staged render remains available until read-back
+completes. After the push, a fresh remote checkout must resolve to the pushed commit and contain byte-identical manifest
+content with the same source/version/status binding. A missing protected-environment value fails the writer before token
+minting or canonical mutation.
 
 The separately named `github-pages` environment is the credential-free GitHub Pages service deployment from the
 protected `gh-pages` branch. It receives neither the Pages-writer App material nor its installation token and is not a

--- a/publication-smoke-tests/src/test/groovy/com/blackbuild/annodocimal/docs/VersionedDocumentationDocumentaryTest.groovy
+++ b/publication-smoke-tests/src/test/groovy/com/blackbuild/annodocimal/docs/VersionedDocumentationDocumentaryTest.groovy
@@ -63,6 +63,12 @@ class VersionedDocumentationDocumentaryTest extends Specification {
         writerJob.contains('Require the requested source to be current master')
         writerJob.contains('Assert the staged artifact is bound to the requested source')
         writerJob.contains('Read back the canonical commit and source manifest')
+        writerJob.contains('cp -R "rendered/$RENDER_PATH" "pages/$SNAPSHOT_PATH"')
+        !writerJob.contains('mv "rendered/$RENDER_PATH" "pages/$SNAPSHOT_PATH"')
+        writerJob.indexOf('cp -R "rendered/$RENDER_PATH" "pages/$SNAPSHOT_PATH"') <
+                writerJob.indexOf('staged_manifest="rendered/$RENDER_PATH/source-manifest.json"')
+        writerJob.indexOf('staged_manifest="rendered/$RENDER_PATH/source-manifest.json"') <
+                writerJob.indexOf('cmp -- "$staged_manifest" "$written_manifest"')
         writerJob.contains('PAGES_WRITER_TOKEN')
         writerJob.contains('HEAD:gh-pages')
         writerJob.contains('if [[ "$STATUS" == archived ]]')


### PR DESCRIPTION
## Summary

The protected Pages writer retained an immutable pending snapshot but failed its post-push byte-identity check because the staged render was moved before the comparison.

This change copies the rendered snapshot into the canonical ledger, preserving the staged manifest through remote read-back. The documentary contract now verifies the copy, rejects the destructive move, and verifies the copy → manifest → comparison ordering.

Related: #71 remains open.

## Scope

No Pages, App, environment, secret, registry, tag, release, or publication configuration changes. Immutable snapshot and two-environment protections are unchanged.

## Validation

- Focused `VersionedDocumentationDocumentaryTest`
- `./gradlew check` (Java 17; Groovy 3/4/5)
- YAML parsing and `git diff --check`
- Standards review: no findings
- Spec review: no findings