### PR TITLE
Require signing for protected publication

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -54,8 +54,9 @@ writer/service jobs have read-only repository access and none of those release s
 persisted.
 
 After reviewer approval, the publishing job repeats the exact-master and pending-handoff checks, requires Java 17, and
-runs `publishCompleteProduct`. That Gradle entry point rejects a non-matching protected stage/version authorization or a
-composite build, runs `check` and the six-coordinate/two-marker product gate before remote tasks, then stages/releases
+runs `publishCompleteProduct`. That Gradle entry point requires each configured publication signature to execute,
+rejects a non-matching protected stage/version authorization or a composite build, runs `check` and the
+six-coordinate/two-marker product gate before remote tasks, then stages/releases
 the Maven Central product and publishes both Plugin Portal markers. It does not create a tag, GitHub Release, or public
 Pages snapshot. The exact protected workflow is not a replacement for the existing protected Pages dispatches: first
 stage pending documentation, then publish the product, then complete #44 public resolve-back, then create the exact tag

--- a/buildSrc/src/main/groovy/annodocimal-base.conventions.gradle
+++ b/buildSrc/src/main/groovy/annodocimal-base.conventions.gradle
@@ -36,7 +36,11 @@ dependencies {
 
 afterEvaluate {
     signing {
-        required { gradle.taskGraph.hasTask("publish") || gradle.taskGraph.hasTask("publishToMavenLocal") }
+        required {
+            gradle.taskGraph.hasTask("publish") ||
+                    gradle.taskGraph.hasTask("publishToMavenLocal") ||
+                    gradle.taskGraph.hasTask(':publishCompleteProduct')
+        }
         publishing.publications.configureEach {
             sign it
         }

--- a/publication-smoke-tests/src/test/groovy/com/blackbuild/annodocimal/publication/ProtectedReleaseAuthorizationContractTest.groovy
+++ b/publication-smoke-tests/src/test/groovy/com/blackbuild/annodocimal/publication/ProtectedReleaseAuthorizationContractTest.groovy
@@ -103,6 +103,11 @@ class ProtectedReleaseAuthorizationContractTest extends Specification {
         convention.contains("tasks.register('publishCompleteProduct')")
         convention.contains('Remote publication must use publishCompleteProduct for the complete product')
 
+        and: 'the protected aggregate task makes every configured publication signature mandatory'
+        String baseConvention = new File(repository, 'buildSrc/src/main/groovy/annodocimal-base.conventions.gradle').text
+        baseConvention.contains("gradle.taskGraph.hasTask(':publishCompleteProduct')")
+        runbook.contains('requires each configured publication signature to execute')
+
         and: 'the runbook keeps Page authority, public resolve-back, tags, and CHANGES-derived releases outside this workflow'
         runbook.contains('`release-candidate`')
         runbook.contains('`final-release`')


### PR DESCRIPTION
## What changed

- Makes protected `publishCompleteProduct` require every configured publication signature.
- Adds a #45 contract regression for that aggregate task condition.
- Records the mandatory signature gate in `RELEASING.md`.

## Why

The `1.0.0-rc.3` Central staging attempt created a staging repository and uploaded the product, but signing tasks were skipped. Central rejected the unsigned artifacts.

No public artifact, tag, GitHub Release, or public documentation snapshot was created.

## Scope and recovery

This changes no credential, workflow permission, Pages, registry, tag, or release state.

`1.0.0-rc.3` is not reused. After this merges, the next separately authorized candidate is `1.0.0-rc.4`.

#45 remains open.

## Validation

- Focused `ProtectedReleaseAuthorizationContractTest`
- `./gradlew check` — Java 17, Groovy 3/4/5
- `git diff --check`
- Standards review: 0 findings
- Spec review: 0 findings