### PR TITLE
Guard release publication POM version parity (#45)

### DIFF
--- a/.github/workflows/publish-protected-release.yml
+++ b/.github/workflows/publish-protected-release.yml
@@ -78,6 +78,17 @@ jobs:
           -Prelease.version="$RELEASE_VERSION"
           --no-build-cache
           --no-daemon
+      - name: Require every generated publication POM to match before selecting an environment
+        shell: bash
+        env:
+          RELEASE_STAGE: ${{ inputs.stage }}
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: >-
+          ./gradlew verifyProtectedPublicationPomParity
+          -Prelease.stage="$RELEASE_STAGE"
+          -Prelease.version="$RELEASE_VERSION"
+          --no-build-cache
+          --no-daemon
       - id: select-environment
         shell: bash
         env:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -35,7 +35,7 @@ Complete these checks while no protected environment has been selected. This is 
 4. Confirm the authorized RC or final protected environment contains only its scoped Maven Central, Plugin Portal, signing, and release-record credentials. Confirm the dedicated `annodocimal-pages-writer` environment and App credentials remain available only to the protected canonical Pages writer. Do not print, copy, inspect, or test a secret value in a command or evidence record.
 5. Confirm the proposed tag `v<version>`, all Maven coordinates, both Plugin Portal marker coordinates, Pages snapshot paths, and the GitHub Release record are absent. A release must not replace an existing public version.
 
-The protected release workflow itself needs an unprivileged preflight job. It strictly accepts only `rc` or `final`, maps that accepted value to exactly the corresponding protected environment, and exports that selected environment as a job output. The publishing job consumes that output. Invalid input must reach neither protected environment nor secret; do not use a fallback expression that could select the final environment before rejecting an unexpected stage.
+The protected release workflow itself needs an unprivileged preflight job. It strictly accepts only `rc` or `final`, regenerates every product and Plugin Portal-marker POM, and rejects any POM whose root version differs from the exact release input before selecting an environment. It maps an accepted value to exactly the corresponding protected environment and exports that selected environment as a job output. The publishing job consumes that output. Invalid input or POM identity must reach neither protected environment nor secret; do not use a fallback expression that could select the final environment before rejecting an unexpected stage.
 
 ## Protected authorization workflow
 
@@ -54,7 +54,7 @@ writer/service jobs have read-only repository access and none of those release s
 persisted.
 
 After reviewer approval, the publishing job repeats the exact-master and pending-handoff checks, requires Java 17, and
-runs `publishCompleteProduct`. Before Maven Central staging can initialize, its non-publishing signing-readiness gate
+runs `publishCompleteProduct`. Before Maven Central staging can initialize, its unprivileged POM-parity and non-publishing signing-readiness gates
 executes every configured publication signature with the protected in-memory signatory. The entry point then requires each configured
 publication signature to execute, rejects a non-matching protected stage/version authorization or a composite build, runs `check` and the
 six-coordinate/two-marker product gate before remote tasks, then stages/releases

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ import com.blackbuild.annodocimal.docs.PreviewRenderedDocumentationTask
 import com.blackbuild.annodocimal.docs.VersionedDocumentationRenderer
 import com.blackbuild.annodocimal.docs.VerifyRenderedDocumentationSiteTask
 import com.blackbuild.annodocimal.docs.VerifyVersionedDocumentationRendererTask
+import groovy.xml.XmlSlurper
 
 buildscript {
     repositories {
@@ -359,8 +360,34 @@ def verifyProtectedSigningReadiness = tasks.register('verifyProtectedSigningRead
     }
 }
 
+def verifyProtectedPublicationPomParity = tasks.register('verifyProtectedPublicationPomParity') {
+    group = 'verification'
+    description = 'Requires every generated protected-release POM to carry the exact release version before environment selection or staging.'
+    dependsOn tasks.named('verifyUnprivilegedReleaseInputs')
+    publicationAuditModules.each { module ->
+        dependsOn "${module.project}:generatePomFileFor${module.publication.capitalize()}Publication"
+    }
+
+    doLast {
+        String releaseVersion = providers.gradleProperty('release.version').get()
+        publicationAuditModules.each { module ->
+            def publicationProject = project(module.project)
+            def publication = publicationProject.publishing.publications.getByName(module.publication)
+            if (publication.version.toString() != releaseVersion)
+                throw new GradleException("${module.project}:${module.publication} version ${publication.version} does not match protected release $releaseVersion")
+
+            File pom = publicationProject.layout.buildDirectory.file(
+                    "publications/${module.publication}/pom-default.xml").get().asFile
+            String pomVersion = new XmlSlurper(false, false).parse(pom).version.text()
+            if (pomVersion != releaseVersion)
+                throw new GradleException("${module.project}:${module.publication} POM version $pomVersion does not match protected release $releaseVersion")
+        }
+    }
+}
+
 tasks.named('initializeSonatypeStagingRepository') {
     dependsOn verifyProtectedSigningReadiness
+    dependsOn verifyProtectedPublicationPomParity
 }
 
 tasks.register('publicRcSmoke') {

--- a/buildSrc/src/main/groovy/annodocimal-base.conventions.gradle
+++ b/buildSrc/src/main/groovy/annodocimal-base.conventions.gradle
@@ -52,6 +52,21 @@ afterEvaluate {
     }
 }
 
+def protectedReleaseVersion = rootProject.providers.gradleProperty('release.version')
+gradle.projectsEvaluated {
+    if (protectedReleaseVersion.present) {
+        publishing.publications.configureEach { publication ->
+            publication.version = protectedReleaseVersion.get()
+            publication.pom.withXml {
+                def versionNodes = asNode().version
+                if (versionNodes.size() != 1)
+                    throw new GradleException("${project.path}:${publication.name} POM has no unique root version")
+                versionNodes[0].setValue(protectedReleaseVersion.get())
+            }
+        }
+    }
+}
+
 publishing.publications.configureEach {
     pom { pom ->
         project.getName()

--- a/publication-smoke-tests/src/test/groovy/com/blackbuild/annodocimal/publication/ProtectedReleaseAuthorizationContractTest.groovy
+++ b/publication-smoke-tests/src/test/groovy/com/blackbuild/annodocimal/publication/ProtectedReleaseAuthorizationContractTest.groovy
@@ -23,6 +23,7 @@
  */
 package com.blackbuild.annodocimal.publication
 
+import groovy.xml.XmlSlurper
 import org.gradle.testkit.runner.GradleRunner
 import spock.lang.Issue
 import spock.lang.See
@@ -70,6 +71,7 @@ class ProtectedReleaseAuthorizationContractTest extends Specification {
         workflow.contains('test ! -e "pages/$RELEASE_VERSION"')
         workflow.contains('.documentation.status == "pending"')
         workflow.contains('./gradlew verifyUnprivilegedReleaseInputs')
+        workflow.contains('./gradlew verifyProtectedPublicationPomParity')
         workflow.contains('test "$master_revision" = "$REVISION"')
 
         and: 'only the dependent protected job receives publication credentials'
@@ -109,6 +111,7 @@ class ProtectedReleaseAuthorizationContractTest extends Specification {
         baseConvention.contains("gradle.taskGraph.hasTask(':verifyProtectedSigningReadiness')")
         baseConvention.contains('useInMemoryPgpKeys(signingKey.get(), signingPassword.get())')
         rootBuild.contains("tasks.register('verifyProtectedSigningReadiness')")
+        rootBuild.contains("tasks.register('verifyProtectedPublicationPomParity')")
         rootBuild.contains("tasks.named('initializeSonatypeStagingRepository')")
         rootBuild.contains('dependsOn "${module.project}:sign${module.publication.capitalize()}Publication"')
         runbook.contains('publication signature to execute')
@@ -190,6 +193,30 @@ class ProtectedReleaseAuthorizationContractTest extends Specification {
         then: 'every publication is signed without initializing Central staging'
         accepted.output.contains('BUILD SUCCESSFUL')
         !accepted.output.contains('Created staging repository')
+    }
+
+    def 'requires every generated POM to match the protected release version before Central staging'() {
+        given: 'the protected release validation environment'
+        File repository = new File(System.getProperty('annodocimal.repository.root'))
+        Map<String, String> environment = new LinkedHashMap<>(System.getenv())
+        environment.remove('ANNODOCIMAL_RELEASE_AUTHORIZED')
+
+        when: 'two immutable RC versions generate their protected publication POMs in sequence without protected authorization'
+        GradleRunner.create()
+                .withProjectDir(repository)
+                .withArguments('verifyProtectedPublicationPomParity', '-Prelease.stage=rc', '-Prelease.version=1.0.0-rc.1')
+                .withEnvironment(environment)
+                .build()
+        def accepted = GradleRunner.create()
+                .withProjectDir(repository)
+                .withArguments('verifyProtectedPublicationPomParity', '-Prelease.stage=rc', '-Prelease.version=1.0.0-rc.5')
+                .withEnvironment(environment)
+                .build()
+
+        then: 'each generated POM carries the second exact release identity without staging'
+        accepted.output.contains('BUILD SUCCESSFUL')
+        !accepted.output.contains('Created staging repository')
+        protectedPomVersions(repository).every { it == '1.0.0-rc.5' }
     }
 
     @Unroll
@@ -296,5 +323,20 @@ esac
         assert directory.mkdir()
         directory.deleteOnExit()
         directory
+    }
+
+    private static List<String> protectedPomVersions(File repository) {
+        [
+                'anno-docimal-annotations/build/publications/mavenJava/pom-default.xml',
+                'anno-docimal-apt/build/publications/mavenJava/pom-default.xml',
+                'anno-docimal-ast/build/publications/mavenJava/pom-default.xml',
+                'anno-docimal-global-ast/build/publications/mavenJava/pom-default.xml',
+                'anno-docimal-generator/build/publications/shadow/pom-default.xml',
+                'anno-docimal-gradle-plugin/build/publications/pluginMaven/pom-default.xml',
+                'anno-docimal-gradle-plugin/build/publications/annoDocimalBasePluginPluginMarkerMaven/pom-default.xml',
+                'anno-docimal-gradle-plugin/build/publications/annoDocimalGroovyPluginPluginMarkerMaven/pom-default.xml'
+        ].collect { path ->
+            new XmlSlurper(false, false).parse(new File(repository, path)).version.text()
+        }
     }
 }


### PR DESCRIPTION
## Summary

- bind every protected Maven and Plugin Portal-marker POM to the exact requested release version
- add an unprivileged POM-parity preflight before protected-environment selection
- repeat the parity gate before Central staging as defense in depth
- cover sequential RC identities so stale POM metadata cannot reach staging

## Validation

- focused protected-release documentary contract test
- credential-free `verifyProtectedPublicationPomParity` for `1.0.0-rc.5`
- `./gradlew check`
- YAML parse and `git diff --check`

No credentials, staging, publication, Pages, tags, or GitHub Release actions occur in this change.